### PR TITLE
Switch to using `npm ci` in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 RUN npm install -g npm
 ENV CLI_WIDTH 80
 COPY package.json /usr/src/app
-RUN npm install 
+RUN npm ci
 RUN npm install -g serve
 EXPOSE 3000
 


### PR DESCRIPTION
Followup to #6. I didn't test this because I don't have a Docker environment set up yet, although it's so trivial I can't imagine it not working. (I need to get Docker set up anyway to test other LibrePhotos PRs.)