### PR TITLE
fixes iss103 duplicate /api/ prefix

### DIFF
--- a/src/api_client/apiClient.js
+++ b/src/api_client/apiClient.js
@@ -51,6 +51,9 @@ Server.interceptors.response.use(function (response) {
       	store.dispatch({type: "REFRESH_ACCESS_TOKEN_FULFILLED", payload: response.data})
         axios.defaults.headers.common['Authorization'] = 'Bearer ' + response.data.access;
         originalRequest.headers['Authorization'] = 'Bearer ' + response.data.access;
+	if (originalRequest.baseURL == originalRequest.url.substring(0, 5)) {
+          originalRequest.baseURL = ''
+        }
         return Server(originalRequest);
       });
   }


### PR DESCRIPTION
added in a check if the base url was already contained in the request url so it wouldn't be added in a second time.