### PR TITLE
Provide overlay component class to Pig

### DIFF
--- a/src/components/photolist/FavoritedOverlay.js
+++ b/src/components/photolist/FavoritedOverlay.js
@@ -1,0 +1,12 @@
+import React, { Component } from "react";
+import { Icon } from "semantic-ui-react";
+
+export default class FavoritedOverlay extends Component {
+    render() {
+        return (
+            <span>
+                { this.props.item.favorited && <Icon name="star" color={"yellow"} /> }
+            </span>
+        );
+    }
+}

--- a/src/components/photolist/PhotoListView.js
+++ b/src/components/photolist/PhotoListView.js
@@ -21,6 +21,7 @@ import { serverAddress } from "../../api_client/apiClient";
 import { LightBox } from "../lightbox/LightBox";
 import _ from "lodash";
 import getToolbar from "../photolist/Toolbar";
+import FavoritedOverlay from "./FavoritedOverlay";
 
 var TOP_MENU_HEIGHT = 45; // don't change this
 var SIDEBAR_WIDTH = 85;
@@ -422,6 +423,7 @@ export class PhotoListView extends Component {
                   url.split(";")[0]
                 );
               }}
+              overlay={FavoritedOverlay}
             >
             </Pig>
           </div>


### PR DESCRIPTION
Add component class for showing "favorited" overlay on images in list view, and provide it to Pig (from react-pig).

This PR should be merged before https://github.com/derneuere/react-pig/pull/7, so that current functionality is not lost.