### PR TITLE
#310: Use rating for favorited

### DIFF
--- a/src/components/lightbox/Toolbar.js
+++ b/src/components/lightbox/Toolbar.js
@@ -75,7 +75,7 @@ export default class Toolbar extends Component {
             disabled={this.props.isPublic}
             onClick={() => {
               const image_hash = this.props.photosDetail.image_hash;
-              const val = !this.props.photosDetail.favorited;
+              const val = !(this.props.photosDetail.rating >= this.props.favorite_min_rating);
               this.props.dispatch(setPhotosFavorite([image_hash], val));
             }}
             color="black"
@@ -84,7 +84,7 @@ export default class Toolbar extends Component {
           >
             <Icon
               name="star"
-              color={this.props.photosDetail.favorited ? "yellow" : "grey"}
+              color={this.props.photosDetail.rating >= this.props.favorite_min_rating ? "yellow" : "grey"}
             />
           </Button>
         )}
@@ -135,5 +135,6 @@ Toolbar = connect((store) => {
     generatingCaptionIm2txt: store.photos.generatingCaptionIm2txt,
     generatedCaptionIm2txt: store.photos.generatedCaptionIm2txt,
     photos: store.photos.photos,
+    favorite_min_rating: store.user.userSelfDetails.favorite_min_rating,
   };
 })(Toolbar);

--- a/src/components/photolist/FavoritedOverlay.js
+++ b/src/components/photolist/FavoritedOverlay.js
@@ -1,12 +1,20 @@
 import React, { Component } from "react";
 import { Icon } from "semantic-ui-react";
+import { connect } from "react-redux";
 
 export default class FavoritedOverlay extends Component {
     render() {
         return (
             <span>
-                { this.props.item.favorited && <Icon name="star" color={"yellow"} /> }
+                { this.props.item.rating >= this.props.favorite_min_rating && <Icon name="star" color={"yellow"} /> }
             </span>
         );
     }
 }
+
+FavoritedOverlay = connect((store) => (
+        {
+            favorite_min_rating: store.user.userSelfDetails.favorite_min_rating,
+        }
+    )
+)(FavoritedOverlay);

--- a/src/components/photolist/PhotoListView.js
+++ b/src/components/photolist/PhotoListView.js
@@ -22,6 +22,7 @@ import { LightBox } from "../lightbox/LightBox";
 import _ from "lodash";
 import getToolbar from "../photolist/Toolbar";
 import FavoritedOverlay from "./FavoritedOverlay";
+import { fetchSiteSettings } from "../../actions/utilActions";
 
 var TOP_MENU_HEIGHT = 45; // don't change this
 var SIDEBAR_WIDTH = 85;
@@ -51,6 +52,7 @@ export class PhotoListView extends Component {
   componentDidMount() {
     this.handleResize();
     window.addEventListener("resize", this.handleResize);
+    this.props.dispatch(fetchSiteSettings());
   }
   componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);

--- a/src/layouts/settings/AdminPage.js
+++ b/src/layouts/settings/AdminPage.js
@@ -28,6 +28,7 @@ import {
 } from '../../actions/utilActions';
 import SortableTree from 'react-sortable-tree';
 import FileExplorerTheme from 'react-sortable-tree-theme-file-explorer';
+import SiteSettings from './SiteSettings';
 
 
 export class AdminPage extends Component {
@@ -56,44 +57,11 @@ export class AdminPage extends Component {
 
         <Divider />
         <Header as="h3">Site settings</Header>
-
-        <Grid>
-          <Grid.Row>
-            <Grid.Column width={4} textAlign="left">
-              <b>Allow user registration</b>
-            </Grid.Column>
-            <Grid.Column width={12}>
-              <Form>
-                <Form.Group>
-                  <Form.Field>
-                    <Radio
-                      label="Allow"
-                      name="radioGroup"
-                      onChange={() =>
-                        this.props.dispatch(
-                          setSiteSettings({allow_registration: true}),
-                        )
-                      }
-                      checked={this.props.siteSettings.allow_registration}
-                    />
-                  </Form.Field>
-                  <Form.Field>
-                    <Radio
-                      label="Do not allow"
-                      name="radioGroup"
-                      onChange={() =>
-                        this.props.dispatch(
-                          setSiteSettings({allow_registration: false}),
-                        )
-                      }
-                      checked={!this.props.siteSettings.allow_registration}
-                    />
-                  </Form.Field>
-                </Form.Group>
-              </Form>
-            </Grid.Column>
-          </Grid.Row>
-        </Grid>
+        <SiteSettings
+          allow_registration={this.props.siteSettings.allow_registration}
+          default_favorite_min_rating={this.props.siteSettings.default_favorite_min_rating}
+          dispatch={this.props.dispatch}
+        />
 
         <Divider />
         <Header as="h3">
@@ -113,7 +81,7 @@ export class AdminPage extends Component {
             <Table.Body>
               {this.props.userList.map(user => {
                 return (
-                    <Table.Row>
+                    <Table.Row key={user.username}>
                       <Table.Cell>{user.username}</Table.Cell>
                       <Table.Cell error={!user.scan_directory}>
                         <Icon

--- a/src/layouts/settings/AdminPage.js
+++ b/src/layouts/settings/AdminPage.js
@@ -18,7 +18,6 @@ import { connect } from 'react-redux';
 import Modal from 'react-modal';
 import moment from 'moment';
 import {
-  setSiteSettings,
   fetchSiteSettings,
   fetchJobList,
   deleteJob,
@@ -59,7 +58,6 @@ export class AdminPage extends Component {
         <Header as="h3">Site settings</Header>
         <SiteSettings
           allow_registration={this.props.siteSettings.allow_registration}
-          default_favorite_min_rating={this.props.siteSettings.default_favorite_min_rating}
           dispatch={this.props.dispatch}
         />
 

--- a/src/layouts/settings/Settings.js
+++ b/src/layouts/settings/Settings.js
@@ -757,6 +757,56 @@ export class Settings extends Component {
           </Grid.Row>
         </Grid>
 
+        <Header as="h3">Favorite options</Header>
+        <Grid>
+          <Grid.Row>
+            <Grid.Column width={4} textAlign="left">
+              <b>Minimum image rating to interpret as favorite</b>
+            </Grid.Column>
+            <Grid.Column width={12}>
+              <select
+                value={this.state.userSelfDetails.favorite_min_rating}
+                onChange={(event) => {
+                  this.setState({
+                    userSelfDetails: {
+                      ...this.state.userSelfDetails,
+                      favorite_min_rating: parseInt(event.target.value),
+                    },
+                  }, () => { console.log(this.state.userSelfDetails) });
+                }}
+              >
+                <option value="" disabled selected>
+                  Minimum rating
+                </option>
+                <option value={1}>1</option>
+                <option value={2}>2</option>
+                <option value={3}>3</option>
+                <option value={4}>4</option>
+                <option value={5}>5</option>
+              </select>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column width={12}>
+              <Button
+                type="submit"
+                color="green"
+                onClick={() => {
+                  const newUserData = this.state.userSelfDetails;
+                  console.log(newUserData);
+                  delete newUserData["scan_directory"];
+                  delete newUserData["avatar"];
+                  this.props.dispatch(manageUpdateUser(newUserData));
+                  if (typeof this.props.onRequestClose == 'function')
+                    this.props.onRequestClose();
+                }}
+              >
+                Update
+              </Button>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+
         <ModalNextcloudScanDirectoryEdit
           onRequestClose={() => {
             this.setState({ modalNextcloudScanDirectoryOpen: false });

--- a/src/layouts/settings/SiteSettings.js
+++ b/src/layouts/settings/SiteSettings.js
@@ -40,35 +40,6 @@ export default class SiteSettings extends Component {
                     </Form>
                 </Grid.Column>
             </Grid.Row>
-
-            <Grid.Row>
-                <Grid.Column width={4} textAlign="left">
-                    <b>Default minimum image rating to interpret as favorite</b>
-                </Grid.Column>
-                <Grid.Column width={12}>
-                    <Form>
-                        <Form.Group>
-                            <Form.Field>
-                                <select
-                                    value={this.props.default_favorite_min_rating}
-                                    onChange={(event) => {
-                                        this.props.dispatch(setSiteSettings({ default_favorite_min_rating: event.target.value }));
-                                    }}
-                                >
-                                    <option value="" disabled>
-                                        Minimum rating
-                                    </option>
-                                    <option value={1}>1</option>
-                                    <option value={2}>2</option>
-                                    <option value={3}>3</option>
-                                    <option value={4}>4</option>
-                                    <option value={5}>5</option>
-                                </select>
-                            </Form.Field>
-                        </Form.Group>
-                    </Form>
-                </Grid.Column>
-            </Grid.Row>
         </Grid>
     )}
 }

--- a/src/layouts/settings/SiteSettings.js
+++ b/src/layouts/settings/SiteSettings.js
@@ -1,0 +1,74 @@
+import React, { Component } from 'react';
+import { Form, Grid, Radio, Input } from 'semantic-ui-react';
+import { setSiteSettings } from '../../actions/utilActions';
+
+export default class SiteSettings extends Component {
+    render() { return (
+        <Grid>
+            <Grid.Row>
+                <Grid.Column width={4} textAlign="left">
+                    <b>Allow user registration</b>
+                </Grid.Column>
+                <Grid.Column width={12}>
+                    <Form>
+                        <Form.Group>
+                            <Form.Field>
+                                <Radio
+                                    label="Allow"
+                                    name="radioGroup"
+                                    onChange={() =>
+                                        this.props.dispatch(
+                                            setSiteSettings({ allow_registration: true }),
+                                        )
+                                    }
+                                    checked={this.props.allow_registration}
+                                />
+                            </Form.Field>
+                            <Form.Field>
+                                <Radio
+                                    label="Do not allow"
+                                    name="radioGroup"
+                                    onChange={() =>
+                                        this.props.dispatch(
+                                            setSiteSettings({ allow_registration: false }),
+                                        )
+                                    }
+                                    checked={!this.props.allow_registration}
+                                />
+                            </Form.Field>
+                        </Form.Group>
+                    </Form>
+                </Grid.Column>
+            </Grid.Row>
+
+            <Grid.Row>
+                <Grid.Column width={4} textAlign="left">
+                    <b>Default minimum image rating to interpret as favorite</b>
+                </Grid.Column>
+                <Grid.Column width={12}>
+                    <Form>
+                        <Form.Group>
+                            <Form.Field>
+                                <select
+                                    value={this.props.default_favorite_min_rating}
+                                    onChange={(event) => {
+                                        this.props.dispatch(setSiteSettings({ default_favorite_min_rating: event.target.value }));
+                                    }}
+                                >
+                                    <option value="" disabled>
+                                        Minimum rating
+                                    </option>
+                                    <option value={1}>1</option>
+                                    <option value={2}>2</option>
+                                    <option value={3}>3</option>
+                                    <option value={4}>4</option>
+                                    <option value={5}>5</option>
+                                </select>
+                            </Form.Field>
+                        </Form.Group>
+                    </Form>
+                </Grid.Column>
+            </Grid.Row>
+        </Grid>
+    )}
+}

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -28,6 +28,16 @@ export default function reducer(
       return { ...state, fetchingUserDetails: false, error: action.payload };
     }
 
+    case "UPDATE_USER_FULFILLED": {
+      let newState = {
+        ...state,
+      };
+      if (action.payload.favorite_min_rating !== undefined) {
+        newState.userSelfDetails.favorite_min_rating = action.payload.favorite_min_rating;
+      }
+      return newState;
+    }
+
     default: {
       return { ...state };
     }


### PR DESCRIPTION
Show photos with a rating greater than a user-set minimum rating (default 4) as favorited.

When a user marks a photo as favorite, set rating to that same favorite minimum rating.

Admin can set the default favorite minimum rating for new users.

This PR should be merged together with the one in backend (https://github.com/LibrePhotos/librephotos/pull/312).