### PR TITLE
-#310: Let user configure save_metadata_to_disk

### DIFF
--- a/src/layouts/settings/Settings.js
+++ b/src/layouts/settings/Settings.js
@@ -842,6 +842,34 @@ export class Settings extends Component {
             </Grid.Column>
           </Grid.Row>
           <Grid.Row>
+            <Grid.Column width={4} textAlign="left">
+              <b>Synchronize rating to disk</b>
+            </Grid.Column>
+            <Grid.Column width={12}>
+              <select
+                value={this.state.userSelfDetails.save_metadata_to_disk}
+                onChange={(event) => {
+                  this.setState(
+                    {
+                      userSelfDetails: {
+                        ...this.state.userSelfDetails,
+                        save_metadata_to_disk: event.target.value,
+                      },
+                    },
+                    () => {
+                      console.log(this.state.userSelfDetails);
+                    }
+                  );
+                }}
+              >
+                <option value="" disabled selected />
+                <option value={"OFF"}>Off</option>
+                <option value={"SIDECAR_FILE"}>Save to sidecar</option>
+                <option value={"MEDIA_FILE"}>Save to media file</option>
+              </select>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
             <Grid.Column width={12}>
               <Button
                 type="submit"

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -36,6 +36,10 @@ export default function reducer(
         newState.userSelfDetails.favorite_min_rating =
           action.payload.favorite_min_rating;
       }
+      if (action.payload.save_metadata_to_disk !== undefined) {
+        newState.userSelfDetails.save_metadata_to_disk =
+          action.payload.save_metadata_to_disk;
+      }
       return newState;
     }
 


### PR DESCRIPTION
Add user setting to let user configure if / how metadata (currently only rating) should be saved to disk.

This should be merged after https://github.com/LibrePhotos/librephotos/pull/342