### PR TITLE
-#310: Update favorited photos in groups correctly

### DIFF
--- a/src/reducers/photosReducer.js
+++ b/src/reducers/photosReducer.js
@@ -296,7 +296,7 @@ export default function reducer(
         );
         newPhotosGroupedByDate = newPhotosGroupedByDate.map((group) =>
           // Create a new group object if the photo exists in its items (don't mutate).
-          group.items.find((photo) => photo.id !== photoDetails.image_hash)
+          group.items.findIndex((photo) => photo.id === photoDetails.image_hash) === -1
             ? group
             : {
                 ...group,


### PR DESCRIPTION
This fixes a bug where photos in the timeline would not update their state when marking / unmarking as favorite.

How to test:
1. Open a photo in the lightbox or select one or more photos in the timeline
2. Mark the photo(s) as favorites
3. If in the lightbox, close the lightbox
=> The photo(s) should now show the star icon in the top right corner