### PR TITLE
Fix shift-click properly (where shift-click should work)

### DIFF
--- a/src/components/photolist/PhotoListView.js
+++ b/src/components/photolist/PhotoListView.js
@@ -94,8 +94,8 @@ export class PhotoListView extends Component {
   };
 
   handleClick = (event, item) => {
-    //if an image is selectabel, then handle shift click
-    if (event.shiftKey) {
+    //if an image is selectable, then handle shift click
+    if (this.props.selectable && event.shiftKey) {
       var lastSelectedElement =
         this.state.selectionState.selectedItems.slice(-1)[0];
       if (lastSelectedElement === undefined) {

--- a/src/layouts/SearchView.js
+++ b/src/layouts/SearchView.js
@@ -21,6 +21,7 @@ export class SearchView extends Component {
         isDateView={true}
         photoset={this.props.photosGroupedByDate}
         idx2hash={this.props.photosFlat}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/albums/AlbumPersonGallery.js
+++ b/src/layouts/albums/AlbumPersonGallery.js
@@ -31,6 +31,7 @@ export class AlbumPersonGallery extends Component {
         isDateView={true}
         photoset={this.props.photosGroupedByDate}
         idx2hash={this.props.photosFlat}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/albums/AlbumPlaceGallery.js
+++ b/src/layouts/albums/AlbumPlaceGallery.js
@@ -35,6 +35,7 @@ export class AlbumPlaceGallery extends Component {
             ? groupedPhotos.grouped_photos.flatMap((el) => el.items)
             : []
         }
+        selectable={true}
       />
     );
   }

--- a/src/layouts/albums/AlbumThingGallery.js
+++ b/src/layouts/albums/AlbumThingGallery.js
@@ -35,6 +35,7 @@ export class AlbumThingGallery extends Component {
             ? groupedPhotos.grouped_photos.flatMap((el) => el.items)
             : []
         }
+        selectable={true}
       />
     );
   }

--- a/src/layouts/albums/AlbumUserGallery.js
+++ b/src/layouts/albums/AlbumUserGallery.js
@@ -50,6 +50,7 @@ export class AlbumUserGallery extends Component {
         idx2hash={this.props.photosFlat}
         match={this.props.match}
         isPublic={isPublic}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/photos/FavoritePhotos.js
+++ b/src/layouts/photos/FavoritePhotos.js
@@ -22,6 +22,7 @@ export class FavoritePhotos extends Component {
         isDateView={true}
         photoset={this.props.photosGroupedByDate}
         idx2hash={this.props.photosFlat}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/photos/HiddenPhotos.js
+++ b/src/layouts/photos/HiddenPhotos.js
@@ -22,6 +22,7 @@ export class HiddenPhotos extends Component {
         isDateView={true}
         photoset={this.props.photosGroupedByDate}
         idx2hash={this.props.photosFlat}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/photos/NoTimestampPhotosView.js
+++ b/src/layouts/photos/NoTimestampPhotosView.js
@@ -45,6 +45,7 @@ export class NoTimestampPhotosView extends Component {
           console.log(visibleItems);
           throttle(this.getImages(visibleItems), 500);
         }}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/photos/RecentlyAddedPhotos.js
+++ b/src/layouts/photos/RecentlyAddedPhotos.js
@@ -30,6 +30,7 @@ export class RecentlyAddedPhotos extends Component {
         photoset={this.props.photosFlat}
         idx2hash={this.props.photosFlat}
         dayHeaderPrefix={"Added on "}
+        selectable={true}
       />
     );
   }

--- a/src/layouts/photos/TimestampPhotos.js
+++ b/src/layouts/photos/TimestampPhotos.js
@@ -36,6 +36,7 @@ export class TimestampPhotos extends Component {
         updateGroups={(visibleGroups) =>
           throttle(this.getAlbums(visibleGroups), 500)
         }
+        selectable={true}
       />
     );
   }

--- a/src/layouts/public/UserPublicPage.js
+++ b/src/layouts/public/UserPublicPage.js
@@ -79,6 +79,7 @@ export class UserPublicPage extends Component {
                 this.props.auth.access === undefined ||
                 this.props.auth.access.name !== this.props.match.params.username
               }
+              selectable={true}
             />
           </div>
         </div>


### PR DESCRIPTION
Shift-click should start, or continue, selecting images in all
simple photo list views, i.e. all except Shared photos views.

Shared photos views need special handling since they have multiple
photo list views. This is not handled yet.