### PR TITLE
add optional to deleted and owner in photo schema

### DIFF
--- a/src/actions/photosActions.types.ts
+++ b/src/actions/photosActions.types.ts
@@ -64,11 +64,11 @@ export const PhotoSchema = z.object({
   rating: z.number(),
   hidden: z.boolean(),
   public: z.boolean(),
-  deleted: z.boolean(),
+  deleted: z.boolean().optional(),
   shared_to: z.number().nullable().array(), // TODO: There are sometimes items in the array with value null. Why?!?
   similar_photos: z.object({ image_hash: z.string(), type: z.nativeEnum(MediaType) }).array(),
   video: z.boolean(),
-  owner: SimpleUserSchema,
+  owner: SimpleUserSchema.optional(),
 });
 export type Photo = z.infer<typeof PhotoSchema>;
 


### PR DESCRIPTION
when running the frontend locally I was getting errors from zod. It was complaning that the owner and deleted attributes were not present in the response from (fetchPhotoDetail)[http://github.com/polaroidkidd/librephotos-frontend/blob/c215e9b95eb1b08a2ae8c539870c6d2519b0bff6/src/actions/photosActions.ts#L540-L540]. 

I also couldn't see these attributes being returned in the production environment.

This PR makes these attributes optional.

Additionally I removed the `@typescript-eslint/no-type-alias` eslint rule since it was just getting in the way of Zod's interfaces.