### PR TITLE
Fix Public Photo Share Toast Notification

### DIFF
--- a/src/actions/photosActions.ts
+++ b/src/actions/photosActions.ts
@@ -221,11 +221,11 @@ export function setPhotosPublic(image_hashes: string[], val_public: boolean) {
             updatedPhotos: updatedPhotos,
           },
         });
-        let notificationMessage = i18n.t("toasts.addpublicphoto", {
+        let notificationMessage = i18n.t("toasts.removepublicphoto", {
           numberOfPhotos: image_hashes.length,
         });
         if (val_public) {
-          notificationMessage = i18n.t("toasts.removepublicphoto", {
+          notificationMessage = i18n.t("toasts.addpublicphoto", {
             numberOfPhotos: image_hashes.length,
           });
         }


### PR DESCRIPTION
A regression happened in 4c2612b85c3799c479eee4112413c64d018b0c53 that caused the toast notifications to indicate the opposite effect when sharing a photo publicly.