### PR TITLE
Adjust lightbox sidebar to prevent timeline date overflow

### DIFF
--- a/src/components/lightbox/LightBox.tsx
+++ b/src/components/lightbox/LightBox.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from "../../store/store";
 import { Sidebar } from "./Sidebar";
 import { Toolbar } from "./Toolbar";
 
-let LIGHTBOX_SIDEBAR_WIDTH = 335;
+let LIGHTBOX_SIDEBAR_WIDTH = 320;
 if (window.innerWidth < 600) {
   LIGHTBOX_SIDEBAR_WIDTH = window.innerWidth;
 }


### PR DESCRIPTION
This fixes an overflow that was occuring:

Original:
![image](https://user-images.githubusercontent.com/10717998/178896126-19555229-7cd3-42b1-ab4b-feb8eb003af3.png)

Fixed:
![image](https://user-images.githubusercontent.com/10717998/178896546-e82df71b-a971-4d63-96a0-7186d0af1a5b.png)
