### PR TITLE
Remove unnecessary state and limit useAppSelector (performance fix)

### DIFF
--- a/src/layouts/dataviz/FaceDashboard.tsx
+++ b/src/layouts/dataviz/FaceDashboard.tsx
@@ -29,7 +29,12 @@ export const FaceDashboardComponent = () => {
   const [labeledGroupedByPersonList, setLabeledGroupedByPersonList] = useState<any[]>([]);
 
   const { inferredFacesList, labeledFacesList, fetchingLabeledFacesList, fetchingInferredFacesList } = useAppSelector(
-    store => store.faces
+    store => store.faces, (prev, next) => {
+      return prev.inferredFacesList === next.inferredFacesList &&
+        prev.labeledFacesList === next.labeledFacesList &&
+        prev.fetchingLabeledFacesList == next.fetchingLabeledFacesList &&
+        prev.fetchingInferredFacesList == next.fetchingInferredFacesList 
+    }
   );
 
   const changeTab = number => setActiveItem(number);
@@ -174,6 +179,7 @@ export const FaceDashboardComponent = () => {
     }
     return <div key={key} style={style} />;
   };
+  
   return (
     <div style={{ display: "flex", flexFlow: "column", height: "100%" }}>
       <Stack>

--- a/src/reducers/facesReducer.js
+++ b/src/reducers/facesReducer.js
@@ -2,7 +2,6 @@ import { FacesActions } from "../actions/facesActions";
 
 export default function reducer(
   state = {
-    faces: [],
     fetching: false,
     fetched: false,
 
@@ -13,10 +12,6 @@ export default function reducer(
     inferredFaces: [],
     fetchingInferredFaces: false,
     fetchedInferredFaces: false,
-
-    facesList: [],
-    fetchingFacesList: false,
-    fetchedFacesList: false,
 
     labeledFacesList: [],
     fetchingLabeledFacesList: false,
@@ -40,21 +35,6 @@ export default function reducer(
   let newInferredFacesList;
   let newLabeledFacesList;
   switch (action.type) {
-    // all faces
-    case "FETCH_FACES": {
-      return { ...state, fetching: true };
-    }
-    case "FETCH_FACES_REJECTED": {
-      return { ...state, fetching: false, error: action.payload };
-    }
-    case "FETCH_FACES_FULFILLED": {
-      return {
-        ...state,
-        fetching: false,
-        fetched: true,
-        faces: action.payload,
-      };
-    }
 
     // labeled faces
     case "FETCH_LABELED_FACES": {
@@ -88,21 +68,6 @@ export default function reducer(
       };
     }
 
-    // fast list
-    case "FETCH_FACES_LIST": {
-      return { ...state, fetchingFacesList: true };
-    }
-    case "FETCH_FACES_LIST_REJECTED": {
-      return { ...state, fetchingFacesList: false, error: action.payload };
-    }
-    case "FETCH_FACES_LIST_FULFILLED": {
-      return {
-        ...state,
-        fetchingFacesList: false,
-        fetchedFacesList: true,
-        facesList: action.payload,
-      };
-    }
 
     // labeled faces
     case FacesActions.FETCH_LABELED_FACES_LIST: {
@@ -153,7 +118,6 @@ export default function reducer(
       action.payload.forEach(justLabeledFace => {
         newLabeledFacesList.push(justLabeledFace);
       });
-
       return {
         ...state,
         inferredFacesList: newInferredFacesList,


### PR DESCRIPTION
Before, our subscription to the "faces" portion of the store was too broad, causing lots of unnecessary re-rendering in the FaceDashboard. I limited the scope to be just the things we care about, which improve response time considerably when clicking faces in large datasets.

I also removed portions of the state that aren't being used (there are no actions that set those things, and nothing references them AFAIK).

This should fix Librephotos/librephotos#565.