### PR TITLE
Limit subscription to worker info

### DIFF
--- a/src/components/facedashboard/ButtonHeaderGroup.tsx
+++ b/src/components/facedashboard/ButtonHeaderGroup.tsx
@@ -16,7 +16,8 @@ type Props = {
 };
 
 export function ButtonHeaderGroup(props: Props) {
-  const { queue_can_accept_job, job_detail } = useAppSelector(store => store.worker);
+  const queue_can_accept_job = useAppSelector(store => store.worker.queue_can_accept_job);
+  const job_detail = useAppSelector(store => store.worker.job_detail);
   const { t } = useTranslation();
 
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);

--- a/src/store/worker/workerSlice.ts
+++ b/src/store/worker/workerSlice.ts
@@ -10,7 +10,7 @@ const initialState: IWorkerAvailabilityResponse = {
   queue_can_accept_job: false,
 };
 
-const workerSlicte = createSlice({
+const workerSlice = createSlice({
   name: "worker",
   initialState: initialState,
   reducers: {},
@@ -27,4 +27,4 @@ const workerSlicte = createSlice({
   },
 });
 
-export const worker = workerSlicte.reducer;
+export const worker = workerSlice.reducer;


### PR DESCRIPTION
This is very similar to the previous pull request to limit subscriptions for performance's sake. I noticed that we are constantly re-rendering the button header every two seconds, so this limits that to only when jobs are actively running.

Sorry for the near-duplicate; I didn't get this in fast enough, before you pulled the other one.