### PR TITLE
move support us to top nav on mobile

### DIFF
--- a/src/components/menubars/Footer.tsx
+++ b/src/components/menubars/Footer.tsx
@@ -2,13 +2,10 @@ import { ActionIcon, Divider, Footer, Group, Menu } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import { push } from "redux-first-history";
-import { Heart } from "tabler-icons-react";
 
 import { selectAuthAccess, selectIsAuthenticated } from "../../store/auth/authSelectors";
 import { useAppDispatch, useAppSelector } from "../../store/store";
-import { SUPPORT_LINK } from "../../ui-constants";
 import { getNavigationItems, navigationStyles } from "./navigation";
 
 export function FooterMenu(): JSX.Element {
@@ -24,19 +21,26 @@ export function FooterMenu(): JSX.Element {
     return <div />;
   }
 
-  const navigationItems = getNavigationItems(t, isAuthenticated, canAccess);
-
-  navigationItems.push({ label: t("supportus"), link: SUPPORT_LINK, icon: Heart, color: "pink" });
-
-  const links = navigationItems.map(item => {
+  const links = getNavigationItems(t, isAuthenticated, canAccess).map(item => {
     if (item.display === false) {
       return null;
     }
 
     const link = (
-      <ActionIcon component={Link} to={item.link}>
-        <item.icon className={classes.linkIcon} color={item.color} size={33} style={{ margin: 0 }} />
-      </ActionIcon>
+      <a
+        href={item.link}
+        key={item.label}
+        onClick={event => {
+          event.preventDefault();
+          if (!item.submenu) {
+            dispatch(push(item.link));
+          }
+        }}
+      >
+        <ActionIcon color={item.color} variant="light">
+          <item.icon className={classes.linkIcon} size={33} style={{ margin: 0 }} />
+        </ActionIcon>
+      </a>
     );
 
     if (item.submenu) {

--- a/src/components/menubars/TopMenu.tsx
+++ b/src/components/menubars/TopMenu.tsx
@@ -1,20 +1,21 @@
-import { Avatar, Button, Divider, Grid, Group, Header, Image, Menu } from "@mantine/core";
+import { ActionIcon, Avatar, Button, Divider, Grid, Group, Header, Image, Menu } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import React, { useEffect } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { push } from "redux-first-history";
-import { Adjustments, Book, ChevronDown, Logout, Menu2, Settings, User } from "tabler-icons-react";
+import { Adjustments, Book, Heart, Logout, Menu2, Settings, User } from "tabler-icons-react";
 
 import { toggleSidebar } from "../../actions/uiActions";
 import { api } from "../../api_client/api";
 import { serverAddress } from "../../api_client/apiClient";
 import { logout } from "../../store/auth/authSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
+import { SUPPORT_LINK } from "../../ui-constants";
 import { ChunkedUploadButton } from "../ChunkedUploadButton";
 import { CustomSearch } from "../CustomSearch";
 import { WorkerIndicator } from "./WorkerIndicator";
 
-export const TopMenu = () => {
+export function TopMenu() {
   const dispatch = useAppDispatch();
   const auth = useAppSelector(state => state.auth);
   const userSelfDetails = useAppSelector(state => state.user.userSelfDetails);
@@ -27,7 +28,7 @@ export const TopMenu = () => {
     if (auth.access) {
       dispatch(api.endpoints.fetchUserSelfDetails.initiate(auth.access.user_id));
     }
-  }, [auth.access]);
+  }, [auth.access, dispatch]);
 
   return (
     <Header height={45}>
@@ -56,6 +57,11 @@ export const TopMenu = () => {
         </Grid.Col>
         <Grid.Col span={1}>
           <Group position="right">
+            {!matches && (
+              <ActionIcon onClick={() => dispatch(push(SUPPORT_LINK))} color="pink">
+                <Heart />
+              </ActionIcon>
+            )}
             <ChunkedUploadButton />
             <WorkerIndicator />
             <Menu
@@ -103,4 +109,4 @@ export const TopMenu = () => {
       </Grid>
     </Header>
   );
-};
+}


### PR DESCRIPTION
Another proposal on mobile navigation cleanup. Move the "Support Us" link to the top navigation. 
Updated icons to match desktop navigation icons (with background colour).

![Screenshot from 2022-07-29 20-39-15](https://user-images.githubusercontent.com/1636515/181832250-cb98c6de-081f-497b-835a-e996ed280e8e.png)

