### PR TITLE
Fix bug with manifest listing the wrong icon size

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "192x192",
+      "sizes": "72x72",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
I notice an error in the console where we list favicon.ico as the wrong size (the .ico is 72x72 bug the manifest says 192x192). Fixing the manifest to get rid of this error.