### PR TITLE
Fix/improve logo in dark/lightmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 <a href="https://hosted.weblate.org/engage/librephotos/">
 <img src="https://hosted.weblate.org/widgets/librephotos/-/librephotos-frontend/svg-badge.svg" alt="Translation status" />
 </a>
-<div style="text-align:center"><img width="100" src ="/public/logo-white.png"/></div>
+<div style="text-align:center">
+  <img width="100" src="/public/logo-white.png#gh-dark-mode-only" alt="Librephotos Logo"/>
+  <img width="100" src="/public/logo.png#gh-light-mode-only" alt="Librephotos Logo"/>
+</div>
 
 # LibrePhotos
 


### PR DESCRIPTION
Hi there!
This is a small PR to fix/improve the logo-image in the Readme.
Currently, it is always using the white version of the logo, which means it's invisible when using the Lightmode of GitHub.
This change inserts both the white and the black version of the logo with a special GitHub tag, so it uses the white version in Darkmode and the black version in Lightmode.
See https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/ for more details.
I've also added a ` alt="Librephotos Logo"` attribute to the image to improve accessibility.