### PR TITLE
Add timestamp to faces tooltip

### DIFF
--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -2,9 +2,10 @@ import { Avatar, Box, Center, Indicator, Tooltip } from "@mantine/core";
 import { t } from "i18next";
 import _ from "lodash";
 import React, { useState } from "react";
-
+import { DateTime } from 'luxon';
 import { serverAddress } from "../../api_client/apiClient";
 import { PhotoIcon } from "./PhotoIcon";
+import i18n from "../../i18n";
 
 type Props = {
   cell: any;
@@ -17,6 +18,23 @@ type Props = {
 };
 
 export function FaceComponent(props: Props) {
+  const tooltipLabel = () => (
+      <div>
+        {t<string>("settings.confidencepercentage", {
+              percentage: (props.cell.person_label_probability * 100).toFixed(1),
+            })}
+        <div>
+          {(() => {if (DateTime.fromISO(props.cell.timestamp).isValid) {
+              return DateTime.fromISO(props.cell.timestamp )
+                .setLocale(i18n.resolvedLanguage.replace("_", "-"))
+                .toLocaleString(DateTime.DATETIME_MED)
+              }
+              return ''
+            })()
+          }
+        </div>
+      </div>);
+
   const calculateProbabiltyColor = (labelProbability: number) =>
     labelProbability > 0.9 ? "green" : labelProbability > 0.8 ? "yellow" : labelProbability > 0.7 ? "orange" : "red";
 
@@ -48,9 +66,7 @@ export function FaceComponent(props: Props) {
         <Center>
           <Tooltip
             opened={tooltipOpened && props.activeItem === 1}
-            label={t<string>("settings.confidencepercentage", {
-              percentage: (props.cell.person_label_probability * 100).toFixed(1),
-            })}
+            label={tooltipLabel()}
             position="bottom"
             withArrow
           >
@@ -94,9 +110,13 @@ export function FaceComponent(props: Props) {
       <Center>
         <Tooltip
           opened={tooltipOpened && props.activeItem === 1}
-          label={t<string>("settings.confidencepercentage", {
+          label= {tooltipLabel()}
+
+/*
+          {t<string>("settings.confidencepercentage", {
             percentage: (props.cell.person_label_probability * 100).toFixed(1),
           })}
+*/
           position="bottom"
         >
           <Indicator

--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Center, Indicator, Tooltip } from "@mantine/core";
+import { Avatar, Box, Center, Indicator } from "@mantine/core";
 import _ from "lodash";
 import React, { useState } from "react";
 import { serverAddress } from "../../api_client/apiClient";

--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -18,11 +18,15 @@ type Props = {
 };
 
 export function FaceComponent(props: Props) {
-  const tooltipLabel = () => (
-      <div>
-        {t<string>("settings.confidencepercentage", {
-              percentage: (props.cell.person_label_probability * 100).toFixed(1),
-            })}
+  const tooltipLabel = () => {
+      var confidencePercentage = '';
+      if (props.activeItem === 1) {
+        confidencePercentage = t<string>("settings.confidencepercentage", {
+          percentage: (props.cell.person_label_probability * 100).toFixed(1),
+        })
+      }
+      return (<div>
+        {confidencePercentage}
         <div>
           {(() => {if (DateTime.fromISO(props.cell.timestamp).isValid) {
               return DateTime.fromISO(props.cell.timestamp )
@@ -34,6 +38,7 @@ export function FaceComponent(props: Props) {
           }
         </div>
       </div>);
+  };
 
   const calculateProbabiltyColor = (labelProbability: number) =>
     labelProbability > 0.9 ? "green" : labelProbability > 0.8 ? "yellow" : labelProbability > 0.7 ? "orange" : "red";
@@ -65,7 +70,7 @@ export function FaceComponent(props: Props) {
       >
         <Center>
           <Tooltip
-            opened={tooltipOpened && props.activeItem === 1}
+            opened={tooltipOpened}
             label={tooltipLabel()}
             position="bottom"
             withArrow
@@ -109,14 +114,8 @@ export function FaceComponent(props: Props) {
     >
       <Center>
         <Tooltip
-          opened={tooltipOpened && props.activeItem === 1}
+          opened={tooltipOpened}
           label= {tooltipLabel()}
-
-/*
-          {t<string>("settings.confidencepercentage", {
-            percentage: (props.cell.person_label_probability * 100).toFixed(1),
-          })}
-*/
           position="bottom"
         >
           <Indicator

--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -1,11 +1,10 @@
 import { Avatar, Box, Center, Indicator, Tooltip } from "@mantine/core";
-import { t } from "i18next";
 import _ from "lodash";
 import React, { useState } from "react";
-import { DateTime } from 'luxon';
 import { serverAddress } from "../../api_client/apiClient";
 import { PhotoIcon } from "./PhotoIcon";
-import i18n from "../../i18n";
+import { FaceTooltip } from "./FaceTooltip";
+
 
 type Props = {
   cell: any;
@@ -18,28 +17,6 @@ type Props = {
 };
 
 export function FaceComponent(props: Props) {
-  const tooltipLabel = () => {
-      let confidencePercentage = '';
-      if (props.activeItem === 1) {
-        confidencePercentage = t<string>("settings.confidencepercentage", {
-          percentage: (props.cell.person_label_probability * 100).toFixed(1),
-        })
-      }
-      return (<div>
-        {confidencePercentage}
-        <div>
-          {(() => {if (DateTime.fromISO(props.cell.timestamp).isValid) {
-              return DateTime.fromISO(props.cell.timestamp )
-                .setLocale(i18n.resolvedLanguage.replace("_", "-"))
-                .toLocaleString(DateTime.DATETIME_MED)
-              }
-              return ''
-            })()
-          }
-        </div>
-      </div>);
-  };
-
   const calculateProbabiltyColor = (labelProbability: number) =>
     labelProbability > 0.9 ? "green" : labelProbability > 0.8 ? "yellow" : labelProbability > 0.7 ? "orange" : "red";
 
@@ -69,11 +46,10 @@ export function FaceComponent(props: Props) {
         })}
       >
         <Center>
-          <Tooltip
-            opened={tooltipOpened}
-            label={tooltipLabel()}
-            position="bottom"
-            withArrow
+          <FaceTooltip
+            tooltipOpened={tooltipOpened}
+            activeItem={props.activeItem}
+            cell={props.cell}
           >
             <Indicator
               color={labelProbabilityColor}
@@ -91,7 +67,7 @@ export function FaceComponent(props: Props) {
                 size={props.entrySquareSize - 30}
               />
             </Indicator>
-          </Tooltip>
+          </FaceTooltip>
           {showPhotoIcon}
         </Center>
       </Box>
@@ -113,10 +89,10 @@ export function FaceComponent(props: Props) {
       })}
     >
       <Center>
-        <Tooltip
-          opened={tooltipOpened}
-          label= {tooltipLabel()}
-          position="bottom"
+        <FaceTooltip
+            tooltipOpened={tooltipOpened}
+            activeItem={props.activeItem}
+            cell={props.cell}
         >
           <Indicator
             offset={10}
@@ -135,7 +111,7 @@ export function FaceComponent(props: Props) {
               size={props.entrySquareSize - 10}
             />
           </Indicator>
-        </Tooltip>
+        </FaceTooltip>
         {showPhotoIcon}
       </Center>
     </Box>

--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export function FaceComponent(props: Props) {
   const tooltipLabel = () => {
-      var confidencePercentage = '';
+      let confidencePercentage = '';
       if (props.activeItem === 1) {
         confidencePercentage = t<string>("settings.confidencepercentage", {
           percentage: (props.cell.person_label_probability * 100).toFixed(1),

--- a/src/components/facedashboard/FaceTooltip.tsx
+++ b/src/components/facedashboard/FaceTooltip.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from "@mantine/core";
 import { t } from "i18next";
-import React, { useState } from "react";
+import React from "react";
 import { DateTime } from 'luxon';
 import i18n from "../../i18n";
 

--- a/src/components/facedashboard/FaceTooltip.tsx
+++ b/src/components/facedashboard/FaceTooltip.tsx
@@ -1,0 +1,46 @@
+import { Tooltip } from "@mantine/core";
+import { t } from "i18next";
+import React, { useState } from "react";
+import { DateTime } from 'luxon';
+import i18n from "../../i18n";
+
+type Props = {
+  tooltipOpened: boolean;
+  cell: any;
+  activeItem: number;
+  children?: React.ReactNode;
+};
+
+export function FaceTooltip({tooltipOpened, cell, activeItem, children}: Props) {
+  const confidencePercentageLabel = activeItem === 1
+  ? t<string>("settings.confidencepercentage", {percentage: (cell.person_label_probability * 100).toFixed(1),})
+  : null;
+
+  const dateTimeLabel = DateTime.fromISO(cell.timestamp).isValid
+  ? DateTime.fromISO(cell.timestamp).setLocale(i18n.resolvedLanguage.replace("_", "-")).toLocaleString(DateTime.DATETIME_MED)
+  : null;
+
+  const tooltipIsEmpty = confidencePercentageLabel === null && dateTimeLabel === null;
+  const tooltipLabel = () => {
+    if (tooltipIsEmpty) {
+      return null;
+    }
+    return (<div>
+      {confidencePercentageLabel}
+      <div>
+        {dateTimeLabel}
+      </div>
+    </div>);
+  };
+
+  return (
+    <Tooltip
+      opened={tooltipOpened && !tooltipIsEmpty}
+      label={tooltipLabel()}
+      position="bottom"
+      withArrow
+    >
+      {children}
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
On inferred faces tab, display the date and time of the photo on which the face appears to help identifying people.

Fixes LibrePhotos/librephotos#394
Will probably also help implementing LibrePhotos/librephotos#655

Depends on LibrePhotos/librephotos#663 PR