### PR TITLE
Bug fix Albums shared from me

### DIFF
--- a/src/layouts/sharing/AlbumsShared.js
+++ b/src/layouts/sharing/AlbumsShared.js
@@ -76,7 +76,7 @@ export class AlbumsShared extends Component {
       ).cellContents;
     } else {
       albumGridContents = calculateSharedPhotoGridCells(
-        nextProps.albums.albumsSharedToMe,
+        nextProps.albums.albumsSharedFromMe,
         prevState.numEntrySquaresPerRow
       ).cellContents;
     }


### PR DESCRIPTION
There was a typo that prevented to display Albums shared from me on the "Photos you shared" page.
This PR fixes this bug. 