### PR TITLE
Fix face dashboard confirm button

### DIFF
--- a/src/components/facedashboard/HeaderComponent.tsx
+++ b/src/components/facedashboard/HeaderComponent.tsx
@@ -77,7 +77,7 @@ export function HeaderComponent(props: Props) {
         <Chip variant="filled" radius="xs" size="lg" checked={checked} onChange={handleClick}>
           {cell.name}
         </Chip>
-        {!props.alreadyLabeled && !(props.cell.kind === 'CLUSTER') && <Tooltip label={t("facesdashboard.explanationvalidate")}>
+        {!props.alreadyLabeled && !(props.cell.kind === "CLUSTER" || props.cell.kind === "UNKNOWN") && <Tooltip label={t("facesdashboard.explanationvalidate")}>
             <ActionIcon
               variant="light"
               color="green"

--- a/src/layouts/dataviz/FaceDashboard.tsx
+++ b/src/layouts/dataviz/FaceDashboard.tsx
@@ -258,7 +258,7 @@ export const FaceDashboard = () => {
         </div>
       );
     }
-    return <div key={key} style={style} />;
+    return null;
   };
 
   return (


### PR DESCRIPTION
Solved a bug where the confirm button on group headers could be un-clickable because it is behind a DIV. Remove those unneeded DIVs on group header row.
Also prevent confirm button to appear on group with cell.kind === "UNKNOWN"