### PR TITLE
Restore faces grid position when switching tabs

### DIFF
--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { serverAddress } from "../../api_client/apiClient";
 import { PhotoIcon } from "./PhotoIcon";
 import { FaceTooltip } from "./FaceTooltip";
+import { useAppSelector } from "../../store/store";
 
 
 type Props = {
@@ -12,11 +13,10 @@ type Props = {
   selectMode: boolean;
   entrySquareSize: number;
   isSelected: boolean;
-  activeItem: number;
   handleClick: (e: any, cell: any) => void;
 };
 
-export function FaceComponent({ cell, isScrollingFast, selectMode, entrySquareSize, isSelected, activeItem, handleClick }: Props) {
+export function FaceComponent({ cell, isScrollingFast, selectMode, entrySquareSize, isSelected, handleClick }: Props) {
   const calculateProbabiltyColor = (labelProbability: number) => {
     if (labelProbability > 0.9) return "green";
     if (labelProbability > 0.8) return "yellow";
@@ -27,6 +27,7 @@ export function FaceComponent({ cell, isScrollingFast, selectMode, entrySquareSi
   const labelProbabilityColor = calculateProbabiltyColor(cell.person_label_probability);
   const showPhotoIcon = <PhotoIcon photo={cell.photo} />;
   const [tooltipOpened, setTooltipOpened] = useState(false);
+  const { activeTab } = useAppSelector(store => store.face);
   // TODO: janky shit going on in the next line!
   const faceImageSrc = `${serverAddress}/media/faces/${_.reverse(cell.image.split("/"))[0]}`;
 
@@ -61,7 +62,6 @@ export function FaceComponent({ cell, isScrollingFast, selectMode, entrySquareSi
       <Center>
         <FaceTooltip
             tooltipOpened={tooltipOpened}
-            activeItem={activeItem}
             cell={cell}
         >
           <Indicator
@@ -69,7 +69,7 @@ export function FaceComponent({ cell, isScrollingFast, selectMode, entrySquareSi
             color={labelProbabilityColor}
             onMouseEnter={() => setTooltipOpened(true)}
             onMouseLeave={() => setTooltipOpened(false)}
-            disabled={activeItem === 0}
+            disabled={activeTab === "labeled"}
             size={15}
           >
             <Avatar

--- a/src/components/facedashboard/FaceTooltip.tsx
+++ b/src/components/facedashboard/FaceTooltip.tsx
@@ -3,16 +3,18 @@ import { t } from "i18next";
 import React from "react";
 import { DateTime } from 'luxon';
 import i18n from "../../i18n";
+import { useAppSelector } from "../../store/store";
 
 type Props = {
   tooltipOpened: boolean;
   cell: any;
-  activeItem: number;
   children?: React.ReactNode;
 };
 
-export function FaceTooltip({ tooltipOpened, cell, activeItem, children }: Props) {
-  const confidencePercentageLabel = activeItem === 1
+export function FaceTooltip({ tooltipOpened, cell, children }: Props) {
+  const { activeTab } = useAppSelector(store => store.face);
+  
+  const confidencePercentageLabel = activeTab === "inferred"
   ? t<string>("settings.confidencepercentage", {percentage: (cell.person_label_probability * 100).toFixed(1),})
   : null;
 

--- a/src/components/facedashboard/HeaderComponent.tsx
+++ b/src/components/facedashboard/HeaderComponent.tsx
@@ -5,12 +5,11 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { UserCheck, } from "tabler-icons-react";
 import { api } from "../../api_client/api";
-import { useAppDispatch } from "../../store/store";
+import { useAppDispatch, useAppSelector } from "../../store/store";
 import i18n from "../../i18n";
 
 type Props = {
   cell: any;
-  alreadyLabeled: boolean;
   width: number;
   style: any;
   key: any;
@@ -19,8 +18,9 @@ type Props = {
   selectedFaces: any;
 };
 
-export function HeaderComponent({cell, alreadyLabeled, width, style, key, entrySquareSize, setSelectedFaces, selectedFaces }: Props) {
-  const dispatch = useAppDispatch();
+export function HeaderComponent({cell, width, style, key, entrySquareSize, setSelectedFaces, selectedFaces }: Props) {
+  const { activeTab } = useAppSelector(store => store.face);
+    const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const [checked, setChecked] = useState(false);
 
@@ -75,7 +75,7 @@ export function HeaderComponent({cell, alreadyLabeled, width, style, key, entryS
         <Chip variant="filled" radius="xs" size="lg" checked={checked} onChange={handleClick}>
           {cell.name}
         </Chip>
-        {!alreadyLabeled && !(cell.kind === "CLUSTER" || cell.kind === "UNKNOWN") && <Tooltip label={t("facesdashboard.explanationvalidate")}>
+        {activeTab === "inferred" && !(cell.kind === "CLUSTER" || cell.kind === "UNKNOWN") && <Tooltip label={t("facesdashboard.explanationvalidate")}>
             <ActionIcon
               variant="light"
               color="green"

--- a/src/components/facedashboard/TabComponent.tsx
+++ b/src/components/facedashboard/TabComponent.tsx
@@ -1,30 +1,41 @@
 import { Loader, Tabs } from "@mantine/core";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { useAppSelector, useAppDispatch } from "../../store/store";
+import type { IFacesTab } from "../../store/faces/facesActions.types";
+import { faceActions } from "../../store/faces/faceSlice";
 
 type Props = {
-  activeTab: number;
   width: number;
-  changeTab: (tabIndex: number) => void;
   fetchingLabeledFacesList: boolean;
   fetchingInferredFacesList: boolean;
 };
 
-export function TabComponent({ activeTab, width, changeTab, fetchingLabeledFacesList, fetchingInferredFacesList }: Props) {
+export function TabComponent({ width, fetchingLabeledFacesList, fetchingInferredFacesList }: Props) {
+  const dispatch = useAppDispatch();
+  const { activeTab } = useAppSelector(store => store.face);
+  const setActiveTab = (tabNumber: number) => {
+    if (tabNumber === 0)
+      dispatch(faceActions.changeTab("labeled"));
+    else if (tabNumber === 1)
+      dispatch(faceActions.changeTab("inferred"));
+  };
   const { t } = useTranslation();
 
   return (
-    <Tabs style={{ width: width }} active={activeTab} onTabChange={changeTab}>
+    <Tabs style={{ width: width }} active={activeTab} onTabChange={setActiveTab}>
       <Tabs.Tab
+        name="labeled"
+        value="labeled"
         label={
           <div>
             {t("settings.labeled")} {fetchingLabeledFacesList ? <Loader size="sm" /> : null}
           </div>
         }
-        name="labeled"
       />
       <Tabs.Tab
         name="inferred"
+        value="inferred"
         label={
           <div>
             {t("settings.inferred")} {fetchingInferredFacesList ? <Loader size="sm" /> : null}

--- a/src/layouts/dataviz/FaceDashboard.tsx
+++ b/src/layouts/dataviz/FaceDashboard.tsx
@@ -2,7 +2,7 @@ import { Stack } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
 import { showNotification } from "@mantine/notifications";
 import _ from "lodash";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { AutoSizer, Grid } from "react-virtualized";
 
 import { api, useFetchIncompleteFacesQuery } from "../../api_client/api";
@@ -12,14 +12,15 @@ import { HeaderComponent } from "../../components/facedashboard/HeaderComponent"
 import { TabComponent } from "../../components/facedashboard/TabComponent";
 import { ModalPersonEdit } from "../../components/modals/ModalPersonEdit";
 import i18n from "../../i18n";
+import { faceActions } from "../../store/faces/faceSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 import { calculateFaceGridCellSize, calculateFaceGridCells } from "../../util/gridUtils";
+import type { IFacesTab } from "../../store/faces/facesActions.types";
 
-export const FaceDashboard = () => {
+export function FaceDashboard () {
   const { ref, width } = useElementSize();
-
+  const [currentGridRow, setCurrentGridRow] = useState(0);
   const [lastChecked, setLastChecked] = useState(null);
-  const [activeItem, setActiveItem] = useState(0);
   const [entrySquareSize, setEntrySquareSize] = useState(200);
   const [numEntrySquaresPerRow, setNumEntrySquaresPerRow] = useState(10);
   const [selectMode, setSelectMode] = useState(false);
@@ -39,6 +40,8 @@ export const FaceDashboard = () => {
     }[]
   >([]);
 
+  const { activeTab, tabs } = useAppSelector(store => store.face);
+
   const { inferredFacesList, labeledFacesList } = useAppSelector(
     store => store.face,
     (prev, next) => {
@@ -52,12 +55,43 @@ export const FaceDashboard = () => {
           api.endpoints.fetchFaces.initiate({
             person: element.person,
             page: element.page,
-            inferred: activeItem === 1,
+            inferred: activeTab === "inferred" ?  1 : 0,
           })
         );
       });
     }
   }, [groups]);
+
+  const usePrevious = (value) => {
+    const ref = useRef();
+    useEffect(() => {
+      ref.current = value; //assign the value of ref to the argument
+    },[value]); //this code will run when the value of 'value' changes
+    return ref.current; //in the end, return the current ref value.
+  };
+
+  // @ts-ignore
+  const previousTab: IFacesTab = usePrevious(activeTab);
+  const [scrollTo, setScrollTo] = useState<number | null>(null);
+  
+  const handleScroll = (params: any) => {
+    const {scrollTop} = params;
+    if (scrollTo !== null && scrollTop === scrollTo)
+      setScrollTo(null);
+      setCurrentGridRow(scrollTop);
+      console.log(`Current scroll position ${scrollTop}`);
+  };
+  
+  useEffect(() => {
+    dispatch(
+          faceActions.saveCurrentGridPosition({
+            tab: previousTab,
+            row: currentGridRow,
+          })
+    );
+    console.log(`Set scrollTo to ${tabs[activeTab].currentRow}`)
+    setScrollTo(tabs[activeTab].currentRow);
+  }, [activeTab]);
 
   // ensure that the endpoint is not undefined
   const getEndpointCell = (cellContents, rowStopIndex, columnStopIndex) => {
@@ -69,13 +103,15 @@ export const FaceDashboard = () => {
   };
 
   const onSectionRendered = (params: any) => {
-    const cellContents = activeItem === 1 ? inferredCellContents : labeledCellContents;
+    const cellContents = activeTab === 'labeled' ? labeledCellContents : inferredCellContents;
     const startPoint = cellContents[params.rowOverscanStartIndex][params.columnOverscanStartIndex];
     const endPoint = getEndpointCell(cellContents, params.rowOverscanStopIndex, params.columnOverscanStopIndex);
     //flatten labeledCellContents and find the range of cells that are in the viewport
     const flatCellContents = _.flatten(cellContents);
     const startIndex = flatCellContents.findIndex(cell => JSON.stringify(cell) === JSON.stringify(startPoint));
     const endIndex = flatCellContents.findIndex(cell => JSON.stringify(cell) === JSON.stringify(endPoint));
+//    setCurrentGridRow(params.scrollTop);
+//    console.log(`Current Grid row ${currentGridRow}`);
 
     //get the range of cells that are in the viewport
     const visibleCells = flatCellContents.slice(startIndex, endIndex + 1);
@@ -93,7 +129,6 @@ export const FaceDashboard = () => {
     }
   };
 
-  const changeTab = number => setActiveItem(number);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -130,7 +165,7 @@ export const FaceDashboard = () => {
       return;
     }
     if (e.shiftKey) {
-      const currentCellsInRowFormat = activeItem === 0 ? labeledCellContents : inferredCellContents;
+      const currentCellsInRowFormat = activeTab === 'labeled' ? labeledCellContents : inferredCellContents;
 
       const allFacesInCells = [] as any[];
       for (let i = 0; i < currentCellsInRowFormat.length; i++) {
@@ -223,7 +258,7 @@ export const FaceDashboard = () => {
 
   const cellRenderer = ({ columnIndex, key, rowIndex, style }) => {
     const cell =
-      activeItem === 0 ? labeledCellContents[rowIndex][columnIndex] : inferredCellContents[rowIndex][columnIndex];
+      activeTab === "labeled" ? labeledCellContents[rowIndex][columnIndex] : inferredCellContents[rowIndex][columnIndex];
 
     if (cell) {
       if (cell.name) {
@@ -233,7 +268,6 @@ export const FaceDashboard = () => {
             style={style}
             width={width}
             cell={cell}
-            alreadyLabeled={activeItem === 0}
             entrySquareSize={entrySquareSize}
             selectedFaces={selectedFaces}
             setSelectedFaces={setSelectedFaces}
@@ -252,7 +286,6 @@ export const FaceDashboard = () => {
             isScrollingFast={false}
             selectMode={selectMode}
             isSelected={selectedFaces.map(face => face.face_id).includes(cell.id)}
-            activeItem={activeItem}
             entrySquareSize={entrySquareSize}
           />
         </div>
@@ -266,8 +299,6 @@ export const FaceDashboard = () => {
       <Stack>
         <TabComponent
           width={width}
-          activeTab={activeItem}
-          changeTab={changeTab}
           fetchingLabeledFacesList={fetchingLabeledFacesList}
           fetchingInferredFacesList={fetchingInferredFacesList}
         />
@@ -293,7 +324,9 @@ export const FaceDashboard = () => {
               onSectionRendered={onSectionRendered}
               height={height}
               width={width}
-              rowCount={activeItem === 0 ? labeledCellContents.length : inferredCellContents.length}
+              rowCount={activeTab === 'labeled' ? labeledCellContents.length : inferredCellContents.length}
+              scrollTop={scrollTo}
+              onScroll={handleScroll}
             />
           )}
         </AutoSizer>

--- a/src/store/faces/faceSlice.ts
+++ b/src/store/faces/faceSlice.ts
@@ -13,7 +13,10 @@ const initialState: IFacesState = {
   clustered: false,
   error: null,
   activeTab: 'labeled',
-  tabs: {"labeled": {scrollPosition: 0}, "inferred": {scrollPosition: 0}} as ITabSettingsArray
+  tabs: {
+    "labeled": {scrollPosition: 0},
+    "inferred": {scrollPosition: 0}
+  } as ITabSettingsArray,
 };
 
 const faceSlice = createSlice({
@@ -25,13 +28,12 @@ const faceSlice = createSlice({
         activeTab: action.payload,
       }
     ),
-    saveCurrentGridPosition: (state, action: PayloadAction<{tab: IFacesTab, row: number}>) => {
-      const {tab, row} = action.payload;
-      console.log(`Saving position for ${tab} ${row}`);
+    saveCurrentGridPosition: (state, action: PayloadAction<{tab: IFacesTab, position: number}>) => {
+      const {tab, position} = action.payload;
+      console.log(`Saving position for ${tab} ${position}`);
       if (tab in state.tabs) {
-//        debugger;
         // @ts-ignore
-        state.tabs[tab].currentRow = row;
+        state.tabs[tab].scrollPosition = position;
       }
     },
 
@@ -62,7 +64,8 @@ const faceSlice = createSlice({
         };
       })
       .addMatcher(api.endpoints.fetchFaces.matchFulfilled, (state, { meta, payload }) => {
-        const personListToChange = state.activeTab === 'inferred' ? state.inferredFacesList : state.labeledFacesList;
+        const inferred = meta.arg.originalArgs.inferred;
+        const personListToChange = inferred ? state.inferredFacesList : state.labeledFacesList;
         const personId = meta.arg.originalArgs.person;
         //@ts-ignore
         const indexToReplace = personListToChange.findIndex(person => person.id === personId);

--- a/src/store/faces/faceSlice.ts
+++ b/src/store/faces/faceSlice.ts
@@ -1,7 +1,7 @@
-import { createSlice, current } from "@reduxjs/toolkit";
-
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { api } from "../../api_client/api";
-import type { ICompletePersonFace, ICompletePersonFaceList, IFacesState } from "./facesActions.types";
+import type { ICompletePersonFace, ICompletePersonFaceList, IFacesState, IFacesTab, ITabSettingsArray } from "./facesActions.types";
 
 const initialState: IFacesState = {
   labeledFacesList: [] as ICompletePersonFaceList[],
@@ -12,12 +12,30 @@ const initialState: IFacesState = {
   clustering: false,
   clustered: false,
   error: null,
+  activeTab: 'labeled',
+  tabs: {"labeled": {scrollPosition: 0}, "inferred": {scrollPosition: 0}} as ITabSettingsArray
 };
 
 const faceSlice = createSlice({
   name: "face",
   initialState: initialState,
-  reducers: {},
+  reducers: {
+    changeTab: (state, action: PayloadAction<IFacesTab>) => (
+      {...state,
+        activeTab: action.payload,
+      }
+    ),
+    saveCurrentGridPosition: (state, action: PayloadAction<{tab: IFacesTab, row: number}>) => {
+      const {tab, row} = action.payload;
+      console.log(`Saving position for ${tab} ${row}`);
+      if (tab in state.tabs) {
+//        debugger;
+        // @ts-ignore
+        state.tabs[tab].currentRow = row;
+      }
+    },
+
+  },
   extraReducers: builder => {
     builder
       //@ts-ignore
@@ -44,8 +62,7 @@ const faceSlice = createSlice({
         };
       })
       .addMatcher(api.endpoints.fetchFaces.matchFulfilled, (state, { meta, payload }) => {
-        const inferred = meta.arg.originalArgs.inferred;
-        var personListToChange = inferred ? state.inferredFacesList : state.labeledFacesList;
+        const personListToChange = state.activeTab === 'inferred' ? state.inferredFacesList : state.labeledFacesList;
         const personId = meta.arg.originalArgs.person;
         //@ts-ignore
         const indexToReplace = personListToChange.findIndex(person => person.id === personId);

--- a/src/store/faces/facesActions.types.ts
+++ b/src/store/faces/facesActions.types.ts
@@ -61,7 +61,7 @@ export type IPersonFaceListResponse = z.infer<typeof CompletePersonFace>;
 export const PersonFaceListRequest = z.object({
   person: z.number(),
   page: z.number(),
-  inferred: z.number(),
+  inferred: z.boolean(),
 });
 export type IPersonFaceListRequest = z.infer<typeof PersonFaceListRequest>;
 

--- a/src/store/faces/facesActions.types.ts
+++ b/src/store/faces/facesActions.types.ts
@@ -9,7 +9,23 @@ export type IFacesState = {
   clustering: boolean;
   clustered: boolean;
   error: any;
+  activeTab: IFacesTab;
+  tabs: ITabSettingsArray;
 };
+
+const FacesTab = z.enum(["labeled", "inferred"]);
+export type IFacesTab = z.infer<typeof FacesTab>;
+
+export const TabSettings = z.object({
+  scrollPosition: z.number(),
+});
+
+export type ITabSettings = z.infer<typeof TabSettings>;
+export const TabSettingsArray = z.record(
+  FacesTab,
+  TabSettings
+);
+export type ITabSettingsArray = z.infer<typeof TabSettingsArray>;
 
 export const IncompletePersonFace = z.object({
   id: z.number(),
@@ -45,7 +61,7 @@ export type IPersonFaceListResponse = z.infer<typeof CompletePersonFace>;
 export const PersonFaceListRequest = z.object({
   person: z.number(),
   page: z.number(),
-  inferred: z.boolean(),
+  inferred: z.number(),
 });
 export type IPersonFaceListRequest = z.infer<typeof PersonFaceListRequest>;
 


### PR DESCRIPTION
When switching between tabs on the faces dashboard, the grid position of each tab was not maintained.
This PR solves this issue.