### PR TITLE
fix LibrePhotos/librephotos #689

### DIFF
--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -21,6 +21,7 @@ describe("email regex test", () => {
       "_______@example.com",
       "valid.name@aa.bb.cc.dd.ee.ff.gg.hh.jj.com",
       "a@bcd.ef",
+      "first.m.last@domain.com",
     ];
 
     validGoodEmailSamples.forEach(sample => {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -5,7 +5,7 @@ import type { UserPhotosGroup } from "../actions/photosActions";
 import type { DatePhotosGroup, IncompleteDatePhotosGroup, PigPhoto } from "../actions/photosActions.types";
 import i18n from "../i18n";
 
-export const EMAIL_REGEX = /^\w+([-.]?\w+\.?\+?\w+[-.]?\w+)?@(\w+-?\w+\.){1,9}[a-z]{2,}$/;
+export const EMAIL_REGEX = /^\w+([-.]?\w+){0,2}(\+?\w+([-.]?\w+){0,2})?@(\w+-?\w+\.){1,9}[a-z]{2,}$/;
 
 export const copyToClipboard = (str: string) => {
   if (navigator.clipboard) {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -5,7 +5,7 @@ import type { UserPhotosGroup } from "../actions/photosActions";
 import type { DatePhotosGroup, IncompleteDatePhotosGroup, PigPhoto } from "../actions/photosActions.types";
 import i18n from "../i18n";
 
-export const EMAIL_REGEX = /^\w+([-.]?\w+\+?\w+[-.]?\w+)?@(\w+-?\w+\.){1,9}[a-z]{2,}$/;
+export const EMAIL_REGEX = /^\w+([-.]?\w+\.?\+?\w+[-.]?\w+)?@(\w+-?\w+\.){1,9}[a-z]{2,}$/;
 
 export const copyToClipboard = (str: string) => {
   if (navigator.clipboard) {


### PR DESCRIPTION
Fixes https://github.com/LibrePhotos/librephotos/issues/689 by adding `\.?` in the middle of the regex.

I also want to flag that this regex is generally pretty brittle and should probably get an overhaul. I'm not a frontend eng and don't have much experience with email validation in general, but I'm wondering if there's a more-robust solution than an increasingly complex regex. I'll open an issue in https://github.com/LibrePhotos/librephotos since it looks like issues are turned off on this repo