### PR TITLE
Compare datetime rules with default set by IDs

### DIFF
--- a/src/components/settings/ConfigDateTime.tsx
+++ b/src/components/settings/ConfigDateTime.tsx
@@ -45,7 +45,7 @@ export function ConfigDateTime({ value, onChange }: ConfigDateTimeProps) {
     }
 
     const defaultRules = allRules.filter(rule => rule.is_default);
-    setResetButtonDisabled(JSON.stringify(userRules) === JSON.stringify(defaultRules));
+    setResetButtonDisabled(JSON.stringify(userRules.map(r => r.id)) === JSON.stringify(defaultRules.map(r => r.id)));
   }, [allRules, userRules]);
 
   function addRules(newRules: DateTimeRule[]) {

--- a/src/components/settings/date-time-settings.tsx
+++ b/src/components/settings/date-time-settings.tsx
@@ -36,7 +36,7 @@ export const useDateTimeSettingsStyles = createStyles(theme => ({
 }));
 
 export function getRuleExtraInfo(rule: DateTimeRule, t: (s: string, o: Object) => string) {
-  const ignoredProps = ["name", "id", "rule_type", "transform_tz"];
+  const ignoredProps = ["name", "id", "rule_type", "transform_tz", "is_default"];
   return (
     <>
       {Object.entries(rule)


### PR DESCRIPTION
- When comparing date time rules, use rule ID only because other fields are irrelevant. That way, when the user has (old) default rule set, the button to reset to default won't be active. Currently, we compare the list of complete date time rule object and old objects do not have `is_default` property. So even when the user has default rules active, the button to reset to defaults is active.
- Remove `is_default` property from extra rule info in UI.