### PR TITLE
set expiry time to theme cookie so it is preserved when browser is closed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import type { ColorScheme } from "@mantine/core";
 import { AppShell, ColorSchemeProvider, MantineProvider } from "@mantine/core";
 import { NotificationsProvider } from "@mantine/notifications";
-import React, { useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Cookies, CookiesProvider } from "react-cookie";
 import { Route, Routes, useLocation } from "react-router-dom";
 
@@ -51,18 +51,21 @@ import { useAppSelector } from "./store/store";
 const noMenubarPaths = ["/signup", "/login"];
 
 export function App() {
-  const cookies = new Cookies();
+  const cookies = useMemo(() => new Cookies(), []);
   const showSidebar = useAppSelector(store => store.ui.showSidebar);
   const isAuth = useAppSelector(selectIsAuthenticated);
   const [colorScheme, setColorScheme] = useState<ColorScheme>(
     cookies.get("mantine-color-scheme") ? cookies.get("mantine-color-scheme") : "light"
   );
 
-  function toggleColorScheme(value) {
-    const nextColorScheme = value || (colorScheme === "dark" ? "light" : "dark");
-    cookies.set("mantine-color-scheme", nextColorScheme, { maxAge: 60 * 60 * 24 * 356 });
-    setColorScheme(nextColorScheme);
-  }
+  const toggleColorScheme = useCallback(
+    value => {
+      const nextColorScheme = value || (colorScheme === "dark" ? "light" : "dark");
+      cookies.set("mantine-color-scheme", nextColorScheme, { maxAge: 60 * 60 * 24 * 356 });
+      setColorScheme(nextColorScheme);
+    },
+    [colorScheme, cookies]
+  );
 
   const { pathname } = useLocation();
 
@@ -86,7 +89,7 @@ export function App() {
 
   return (
     <CookiesProvider>
-      <ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={value => toggleColorScheme(value)}>
+      <ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>
         <MantineProvider theme={{ colorScheme }} withGlobalStyles withNormalizeCSS>
           <NotificationsProvider autoClose={3000} zIndex={1001}>
             <AppShell

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ export function App() {
 
   function toggleColorScheme(value) {
     const nextColorScheme = value || (colorScheme === "dark" ? "light" : "dark");
-    cookies.set("mantine-color-scheme", nextColorScheme);
+    cookies.set("mantine-color-scheme", nextColorScheme, { maxAge: 60 * 60 * 24 * 356 });
     setColorScheme(nextColorScheme);
   }
 
@@ -68,27 +68,25 @@ export function App() {
 
   const showMenubar = !!(pathname && !noMenubarPaths.includes(pathname));
 
-  const getNavBar = (showMenubar: boolean, showSidebar: boolean, isAuth: boolean) => {
-    if (showMenubar && showSidebar && isAuth) {
+  const getNavBar = (isMenubarVisible: boolean, isSidebarVisible: boolean, isAuthenticated: boolean) => {
+    if (isMenubarVisible && isSidebarVisible && isAuthenticated) {
       return <SideMenuNarrow />;
     }
     return <div />;
   };
 
-  const getHeader = (showMenubar: boolean) => {
-    if (showMenubar) {
-      return isAuth ? <TopMenu /> : <TopMenuPublic />;
+  const getHeader = (isMenubarVisible: boolean) => {
+    if (!isMenubarVisible) {
+      return <div />;
     }
-    return <div />;
+    return isAuth ? <TopMenu /> : <TopMenuPublic />;
   };
 
-  const getFooter = (isAuth: boolean) => {
-    return isAuth ? <FooterMenu /> : <div />;
-  };
+  const getFooter = (isAuthenticated: boolean) => (isAuthenticated ? <FooterMenu /> : <div />);
 
   return (
     <CookiesProvider>
-      <ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>
+      <ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={value => toggleColorScheme(value)}>
         <MantineProvider theme={{ colorScheme }} withGlobalStyles withNormalizeCSS>
           <NotificationsProvider autoClose={3000} zIndex={1001}>
             <AppShell


### PR DESCRIPTION
In order to preserve theme across browser restarts, the theme cookie should have an expiration time. Currently, we are setting it to expire in one year's time.

Fixes https://github.com/LibrePhotos/librephotos/issues/711