### PR TITLE
migrate dir list to RTK

### DIFF
--- a/src/actions/utilActions.js
+++ b/src/actions/utilActions.js
@@ -9,7 +9,6 @@ import { scanPhotos } from "./photosActions";
 import {
   CountStats,
   DeleteMissingPhotosResponse,
-  DirTree,
   GenerateEventAlbumsResponse,
   GenerateEventAlbumsTitlesResponse,
   LocationSunburst,
@@ -18,46 +17,6 @@ import {
   SearchTermExamples,
   WordCloudResponse,
 } from "./utilActions.types";
-
-export function fetchDirectoryTree(path) {
-  return function (dispatch) {
-    dispatch({ type: "FETCH_DIRECTORY_TREE" });
-    Server.get(`dirtree/?path=${path}`)
-      .then(response => {
-        const data = DirTree.array().parse(response.data);
-        dispatch({
-          type: "FETCH_DIRECTORY_TREE_FULFILLED",
-          payload: data,
-        });
-      })
-      .catch(error => {
-        console.error(error);
-        dispatch({ type: "FETCH_DIRECTORY_TREE_REJECTED", payload: error });
-      });
-  };
-}
-
-export function fetchNextcloudDirectoryTree(path) {
-  return function (dispatch) {
-    dispatch({ type: "FETCH_NEXTCLOUD_DIRECTORY_TREE" });
-    Server.get(`nextcloud/listdir/?fpath=${path}`)
-      .then(response => {
-        // To-Do: Needs to be tested...
-        // const data = DirTree.array().parse(response.data);
-        dispatch({
-          type: "FETCH_NEXTCLOUD_DIRECTORY_TREE_FULFILLED",
-          payload: response.data,
-        });
-      })
-      .catch(error => {
-        console.error(error);
-        dispatch({
-          type: "FETCH_NEXTCLOUD_DIRECTORY_TREE_REJECTED",
-          payload: error,
-        });
-      });
-  };
-}
 
 export function updateAvatar(user, form_data) {
   return function (dispatch) {

--- a/src/api_client/dir-tree.ts
+++ b/src/api_client/dir-tree.ts
@@ -1,0 +1,46 @@
+import type { ZodType } from "zod";
+import { z } from "zod";
+
+import { api } from "./api";
+
+export interface DirTree {
+  title: string;
+  absolute_path: string;
+  children: DirTree[];
+}
+
+export type DirTreeResponse = DirTree[];
+
+export const DirTreeSchema: ZodType<DirTree> = z.lazy(() =>
+  z.object({
+    title: z.string(),
+    absolute_path: z.string(),
+    children: z.array(DirTreeSchema),
+  })
+);
+
+export const DirTreeResponseSchema: ZodType<DirTreeResponse> = z.array(DirTreeSchema);
+
+enum DirTreeEndpoints {
+  fetchDirs = "fetchDirs",
+}
+
+export const dirTreeApi = api
+  .injectEndpoints({
+    endpoints: builder => ({
+      [DirTreeEndpoints.fetchDirs]: builder.query<DirTreeResponse, string>({
+        query: (path: string) => `dirtree/?path=${path}`,
+        transformResponse: (response: DirTreeResponse) => DirTreeResponseSchema.parse(response),
+      }),
+    }),
+  })
+  .enhanceEndpoints<"DirTree">({
+    addTagTypes: ["DirTree"],
+    endpoints: {
+      [DirTreeEndpoints.fetchDirs]: {
+        providesTags: ["DirTree"],
+      },
+    },
+  });
+
+export const { useLazyFetchDirsQuery } = dirTreeApi;

--- a/src/api_client/nextcloud.ts
+++ b/src/api_client/nextcloud.ts
@@ -1,16 +1,6 @@
-import { z } from "zod";
-
 import { api } from "./api";
-
-const NextcloudDirEntrySchema = z.object({
-  absolute_path: z.string(),
-  title: z.string(),
-  children: z.array(z.any()),
-});
-
-const NextcloudDirsResponseSchema = z.array(NextcloudDirEntrySchema);
-
-export type NextcloudDirsResponse = z.infer<typeof NextcloudDirsResponseSchema>;
+import type { DirTreeResponse } from "./dir-tree";
+import { DirTreeResponseSchema } from "./dir-tree";
 
 enum NextcloudEndpoints {
   fetchNextcloudDirs = "fetchNextcloudDirs",
@@ -19,9 +9,9 @@ enum NextcloudEndpoints {
 export const nextcloudApi = api
   .injectEndpoints({
     endpoints: builder => ({
-      [NextcloudEndpoints.fetchNextcloudDirs]: builder.query<NextcloudDirsResponse, void>({
+      [NextcloudEndpoints.fetchNextcloudDirs]: builder.query<DirTreeResponse, void>({
         query: () => `nextcloud/listdir/?fpath=/`,
-        transformResponse: response => NextcloudDirsResponseSchema.parse(response),
+        transformResponse: response => DirTreeResponseSchema.parse(response),
       }),
     }),
   })

--- a/src/store/user/user.zod.ts
+++ b/src/store/user/user.zod.ts
@@ -57,7 +57,6 @@ export const ManageUser = z.object({
   first_name: z.string().nullable(),
   last_name: z.string().nullable(),
   password: z.string().optional(),
-  public_sharing: z.boolean(),
 });
 
 export const SimpleUser = z.object({

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -1,4 +1,5 @@
-import { EMAIL_REGEX, fuzzyMatch } from "./util";
+import type { DirTree } from "../api_client/dir-tree";
+import { EMAIL_REGEX, fuzzyMatch, mergeDirTree } from "./util";
 
 describe("email regex test", () => {
   test("good samples should match", () => {
@@ -97,4 +98,86 @@ describe("fuzzyMatch", () => {
       expect(fuzzyMatch(item.query, item.value)).toBe(item.result);
     });
   });
+});
+
+test("merge directory tree", () => {
+  const tree: DirTree[] = [
+    {
+      title: "root",
+      absolute_path: "/",
+      children: [
+        {
+          title: "dir1",
+          absolute_path: "/dir1",
+          children: [
+            {
+              title: "dir1-1",
+              absolute_path: "/dir1/dir1-1",
+              children: [],
+            },
+          ],
+        },
+        {
+          title: "dir2",
+          absolute_path: "/dir2",
+          children: [],
+        },
+      ],
+    },
+  ];
+  const branch: DirTree = {
+    title: "dir1-1",
+    absolute_path: "/dir1/dir1-1",
+    children: [
+      {
+        title: "dir1-1-1",
+        absolute_path: "/dir1/dir1-1/dir1-1-1",
+        children: [
+          {
+            title: "dir1-1-1-1",
+            absolute_path: "/dir1/dir1-1/dir1-1-1/dir1-1-1-1",
+            children: [],
+          },
+        ],
+      },
+    ],
+  };
+  const expected: DirTree[] = [
+    {
+      title: "root",
+      absolute_path: "/",
+      children: [
+        {
+          title: "dir1",
+          absolute_path: "/dir1",
+          children: [
+            {
+              title: "dir1-1",
+              absolute_path: "/dir1/dir1-1",
+              children: [
+                {
+                  title: "dir1-1-1",
+                  absolute_path: "/dir1/dir1-1/dir1-1-1",
+                  children: [
+                    {
+                      title: "dir1-1-1-1",
+                      absolute_path: "/dir1/dir1-1/dir1-1-1/dir1-1-1-1",
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: "dir2",
+          absolute_path: "/dir2",
+          children: [],
+        },
+      ],
+    },
+  ];
+
+  expect(mergeDirTree(tree, branch)).toEqual(expected);
 });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -4,6 +4,7 @@ import { DateTime } from "luxon";
 
 import type { UserPhotosGroup } from "../actions/photosActions";
 import type { DatePhotosGroup, IncompleteDatePhotosGroup, PigPhoto } from "../actions/photosActions.types";
+import type { DirTree } from "../api_client/dir-tree";
 import i18n from "../i18n";
 
 export const EMAIL_REGEX = /^\w+([-.]?\w+){0,2}(\+?\w+([-.]?\w+){0,2})?@(\w+-?\w+\.){1,9}[a-z]{2,}$/;
@@ -88,4 +89,17 @@ export function fuzzyMatch(query: string, value: string): boolean {
     return new RegExp(expression).test(value.toLowerCase());
   }
   return true;
+}
+
+export function mergeDirTree(tree: DirTree[], branch: DirTree): DirTree[] {
+  return tree.map(folder => {
+    if (branch.absolute_path === folder.absolute_path) {
+      return { ...folder, children: branch.children };
+    }
+    if (branch.absolute_path.startsWith(folder.absolute_path)) {
+      const newTreeData = mergeDirTree(folder.children, branch);
+      return { ...folder, children: newTreeData };
+    }
+    return folder;
+  });
 }


### PR DESCRIPTION
- Migrate list of directories of local LP instance.
- Use `DirTree` types for Nextcloud, as they have the same shape.
- Fix directory listing where only first 3 levels are shown. Now it's possible to drill down as far as it goes.
- Hide directory selection when creating new user in admin section. This didn't work anyway because we are using signup flow, and this flow does not support setting scan directory. Should be fixed in the future.