### PR TITLE
Bugfix: don't allow user to submit empty string for newPersonName

### DIFF
--- a/src/components/modals/ModalPersonEdit.tsx
+++ b/src/components/modals/ModalPersonEdit.tsx
@@ -97,7 +97,7 @@ export function ModalPersonEdit(props: Props) {
               onRequestClose();
               setNewPersonName("");
             }}
-            disabled={personExist(newPersonName)}
+            disabled={personExist(newPersonName) || newPersonName.trim().length === 0}
             type="submit"
           >
             {t("personedit.addperson")}


### PR DESCRIPTION
This fixes an issue where a user could submit an empty string for newPersonName in the ModalPersonEdit component from the FaceDashboard.

I did this myself and now I can't access the `/faces` route because FaceComponent expects cell.image to always be a string.

~Any pointers on how to fix that issue with the data on my docker hosted instance would be appreciated.~ (I figured it out).
