### PR TITLE
[WIP] Implement image rotation in frontend

### DIFF
--- a/src/actions/photosActions.ts
+++ b/src/actions/photosActions.ts
@@ -4,7 +4,7 @@ import type { Dispatch } from "redux";
 import { z } from "zod";
 
 // eslint-disable-next-line import/no-cycle
-import { Server } from "../api_client/apiClient";
+import { Server, serverAddress } from "../api_client/apiClient";
 import i18n from "../i18n";
 // eslint-disable-next-line import/no-cycle
 import { PhotosetType } from "../reducers/photosReducer";
@@ -631,6 +631,29 @@ export function editPhoto(image_hash: string, photo_details: any) {
       })
       .catch(error => {
         dispatch({ type: "EDIT_PHOTO_REJECTED" });
+        console.error(error);
+      });
+  };
+}
+
+export function rotatePhoto(image_hash: string, angle: number, flip: boolean = false) {
+  return function (dispatch: Dispatch<any>) {
+    Server.post("photosedit/rotate", { image_hash: image_hash, angle: angle, flip: flip })
+      .then(() => {
+        dispatch({ type: "ROTATE_PHOTO_FULFILLED" });
+        dispatch(fetchPhotoDetail(image_hash));
+        showNotification({
+          message: i18n.t<string>("toasts.rotatephoto"),
+          title: i18n.t<string>("toasts.rotateupdate"),
+          color: "teal",
+        });
+        // Reset the cache
+        fetch(`${serverAddress}/media/thumbnails_big/${image_hash}`, {cache: 'reload', credentials: 'include'});
+        fetch(`${serverAddress}/media/square_thumbnails/${image_hash}`, {cache: 'reload', credentials: 'include'});
+        fetch(`${serverAddress}/media/square_thumbnails_small/${image_hash}`, {cache: 'reload', credentials: 'include'});
+      })
+      .catch(error => {
+        dispatch({ type: "ROTATE_PHOTO_REJECTED" });
         console.error(error);
       });
   };

--- a/src/components/lightbox/Toolbar.tsx
+++ b/src/components/lightbox/Toolbar.tsx
@@ -1,8 +1,8 @@
 import { ActionIcon, Group, Loader } from "@mantine/core";
 import React from "react";
-import { Eye, EyeOff, Globe, InfoCircle, PlayerPause, PlayerPlay, Star } from "tabler-icons-react";
+import { Eye, EyeOff, Globe, InfoCircle, PlayerPause, PlayerPlay, Star, RotateClockwise2, Rotate2 } from "tabler-icons-react";
 
-import { setPhotosFavorite, setPhotosHidden, setPhotosPublic } from "../../actions/photosActions";
+import { rotatePhoto, setPhotosFavorite, setPhotosHidden, setPhotosPublic } from "../../actions/photosActions";
 import { shareAddress } from "../../api_client/apiClient";
 import { playerActions } from "../../store/player/playerSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
@@ -42,6 +42,17 @@ export function Toolbar(props: Props) {
 
   return (
     <Group style={{ paddingBottom: 10, paddingRight: 5 }}>
+
+      {!photosDetail && (
+        <ActionIcon loading disabled={isPublic}>
+          <Rotate2 color="grey" />
+        </ActionIcon>
+      )}
+      {!photosDetail && (
+        <ActionIcon loading disabled={isPublic}>
+          <RotateClockwise2 color="grey" />
+        </ActionIcon>
+      )}
       {!photosDetail && (
         <ActionIcon loading disabled={isPublic}>
           <Eye color="grey" />
@@ -58,6 +69,28 @@ export function Toolbar(props: Props) {
         </ActionIcon>
       )}
       {playButton(photosDetail)}
+      {photosDetail && (
+        <ActionIcon
+          disabled={isPublic}
+          onClick={() => {
+            const { image_hash: imageHash } = photosDetail;
+            dispatch(rotatePhoto(imageHash, -90));
+          }}
+        >
+          <Rotate2 color="grey" />
+        </ActionIcon>
+      )}
+      {photosDetail && (
+        <ActionIcon
+          disabled={isPublic}
+          onClick={() => {
+            const { image_hash: imageHash } = photosDetail;
+            dispatch(rotatePhoto(imageHash, 90));
+          }}
+        >
+          <RotateClockwise2 color="grey" />
+        </ActionIcon>
+      )}
       {photosDetail && (
         <ActionIcon
           disabled={isPublic}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -595,7 +595,9 @@
         "removefacestoperson": "{{numberOfFaces}} face(s) were moved to 'Unknown - Other'",
         "removefacestopersontitle": "Remove faces from person",
         "savecaptions": "Image caption updated successfully",
-        "captionupdate": "Update Caption"
+        "captionupdate": "Update Caption",
+        "rotatephoto": "Photo rotated successfully",
+        "rotateupdate": "Rotate photo"
     },
     "rules": {
         "1": "Local time from DATE_TIME_ORIGINAL exif tag",


### PR DESCRIPTION
Currently just a PoC need help making it work reliably.

Implements changes made in https://github.com/LibrePhotos/librephotos/pull/885 (Issue https://github.com/LibrePhotos/librephotos/issues/856)

Currently it just calls the API endpoint to rotate the image. Ideally it would let the user rotate the image as much as they want and then when closing the LightBox or switching to another image it would send the rotation change to the backend (only when it got actually rotated)

Also after the backend call it should update the cached image and the grid view somehow, so that the user experience is seamless.

I tried updating the cache in my PoC but it doesn't seem to work.

Any help is appreciated!