### PR TITLE
adding front end for photos and videos only filter feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,8 @@ import { Statistics } from "./layouts/dataviz/Statistics";
 import { SignupPage } from "./layouts/login/SignUpPage";
 import { DeletedPhotos } from "./layouts/photos/DeletedPhotos";
 import { FavoritePhotos } from "./layouts/photos/FavoritePhotos";
+import { OnlyPhotos } from "./layouts/photos/OnlyPhotos";
+import { OnlyVideos } from "./layouts/photos/OnlyVideos";
 import { HiddenPhotos } from "./layouts/photos/HiddenPhotos";
 import { NoTimestampPhotosView } from "./layouts/photos/NoTimestampPhotosView";
 import { RecentlyAddedPhotos } from "./layouts/photos/RecentlyAddedPhotos";
@@ -115,6 +117,8 @@ export function App() {
                   <Route path="things" element={<AlbumThing />} />
                   <Route path="recent" element={<RecentlyAddedPhotos />} />
                   <Route path="favorites" element={<FavoritePhotos />} />
+                  <Route path="photos" element={<OnlyPhotos/>} /> 
+                  <Route path="videos" element={<OnlyVideos/>} /> 
                   <Route path="deleted" element={<DeletedPhotos />} />
                   <Route path="hidden" element={<HiddenPhotos />} />
                   <Route path="notimestamp" element={<NoTimestampPhotosView />} />

--- a/src/actions/albumsActions.ts
+++ b/src/actions/albumsActions.ts
@@ -344,11 +344,13 @@ export function fetchAlbumDateList(dispatch: AppDispatch, options: AlbumDateList
   const favorites = options.photosetType === PhotosetType.FAVORITES ? "?favorite=true" : "";
   const publicParam = options.photosetType === PhotosetType.PUBLIC ? "?public=true" : "";
   const hiddenParam = options.photosetType === PhotosetType.HIDDEN ? "?hidden=true" : "";
+  const photos= options.photosetType === PhotosetType.PHOTOS? "?photo=true" : "";
   const deletedParam = options.photosetType === PhotosetType.DELETED ? "?deleted=true" : "";
   const usernameParam = options.username ? `&username=${options.username.toLowerCase()}` : "";
   const personidParam = options.person_id ? `?person=${options.person_id}` : "";
+  const videos= options.photosetType === PhotosetType.VIDEOS ? "?video=true" : "";
   Server.get(
-    `albums/date/list/${favorites}${publicParam}${hiddenParam}${deletedParam}${usernameParam}${personidParam}`,
+    `albums/date/list/${favorites}${publicParam}${hiddenParam}${deletedParam}${usernameParam}${personidParam}${photos}${videos}`,
     {
       timeout: 100000,
     }
@@ -388,13 +390,15 @@ export function fetchAlbumDate(dispatch: AppDispatch, options: AlbumDateOption) 
     },
   });
   const favorites = options.photosetType === PhotosetType.FAVORITES ? "&favorite=true" : "";
+  const photos= options.photosetType === PhotosetType.PHOTOS? "&photo=true" : "";
+  const videos= options.photosetType === PhotosetType.VIDEOS ? "&video=true" : "";
   const publicParam = options.photosetType === PhotosetType.PUBLIC ? "&public=true" : "";
   const usernameParam = options.username ? `&username=${options.username.toLowerCase()}` : "";
   const personidParam = options.person_id ? `&person=${options.person_id}` : "";
   const deletedParam = options.photosetType === PhotosetType.DELETED ? "&deleted=true" : "";
   const hiddenParam = options.photosetType === PhotosetType.HIDDEN ? "&hidden=true" : "";
   Server.get(
-    `albums/date/${options.album_date_id}/?page=${options.page}${favorites}${publicParam}${usernameParam}${personidParam}${deletedParam}${hiddenParam}`
+    `albums/date/${options.album_date_id}/?page=${options.page}${favorites}${publicParam}${usernameParam}${personidParam}${deletedParam}${hiddenParam}${photos}${videos}`
   )
     .then(response => {
       const datePhotosGroup: IncompleteDatePhotosGroup = IncompleteDatePhotosGroupSchema.parse(response.data.results);

--- a/src/components/photolist/DefaultHeader.tsx
+++ b/src/components/photolist/DefaultHeader.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from "react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { push } from "redux-first-history";
-import { Calendar, ChevronDown, Clock, EyeOff, Globe, Star } from "tabler-icons-react";
+import { Calendar, ChevronDown, Clock, EyeOff, Globe, Star ,Photo,Video} from "tabler-icons-react";
 
 import { useFetchUserListQuery } from "../../api_client/api";
 import { i18nResolvedLanguage } from "../../i18n";
@@ -44,7 +44,10 @@ export function DefaultHeader(props: Props) {
       path.startsWith("/favorites") ||
       path.startsWith("/notimestamp") ||
       path.startsWith("/recent") ||
-      path.startsWith("/user/")
+      path.startsWith("/user/") ||
+      path.startsWith("/photos") ||
+      path.startsWith("/videos")
+
     );
   };
 
@@ -138,6 +141,14 @@ export function DefaultHeader(props: Props) {
 
                 <Menu.Item icon={<Star color="yellow" size={14} />} onClick={() => dispatch(push("/favorites"))}>
                   {t("sidemenu.favorites")}
+                </Menu.Item>
+
+                <Menu.Item icon={<Photo color="blue" size={14} />} onClick={() => dispatch(push("/photos"))}>
+                  {t("sidemenu.photos")}
+                </Menu.Item>
+
+                <Menu.Item icon={<Video color="pink" size={14} />} onClick={() => dispatch(push("/videos"))}>
+                  {t("sidemenu.videos")}
                 </Menu.Item>
 
                 <Menu.Item

--- a/src/layouts/photos/OnlyPhotos.tsx
+++ b/src/layouts/photos/OnlyPhotos.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Star } from "tabler-icons-react";
+
+import { fetchAlbumDate, fetchAlbumDateList } from "../../actions/albumsActions";
+import { PhotoListView } from "../../components/photolist/PhotoListView";
+import type { PhotosState } from "../../reducers/photosReducer";
+import { PhotosetType } from "../../reducers/photosReducer";
+import { useAppDispatch, useAppSelector } from "../../store/store";
+
+type FetchedGroup = {
+  id: string;
+  page: number;
+};
+
+export function OnlyPhotos() {
+  const { fetchedPhotosetType, photosFlat, photosGroupedByDate } = useAppSelector(state => state.photos as PhotosState);
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation();
+
+  const [group, setGroup] = useState({} as FetchedGroup);
+
+  useEffect(() => {
+    if (group.id && group.page) {
+      fetchAlbumDate(dispatch, {
+        album_date_id: group.id,
+        page: group.page,
+        photosetType: PhotosetType.PHOTOS,
+      });
+    }
+  }, [group.id, group.page]);
+
+  useEffect(() => {
+    if (fetchedPhotosetType !== PhotosetType.PHOTOS) {
+      fetchAlbumDateList(dispatch, { photosetType: PhotosetType.PHOTOS });
+    }
+  }, [dispatch]); // Only run on first render
+
+  const getAlbums = (visibleGroups: any) => {
+    visibleGroups.forEach((group: any) => {
+      const visibleImages = group.items;
+      if (visibleImages.filter((i: any) => i.isTemp && i.isTemp !== undefined).length > 0) {
+        const firstTempObject = visibleImages.filter((i: any) => i.isTemp)[0];
+        const page = Math.ceil((parseInt(firstTempObject.id,10) + 1) / 100);
+        setGroup({ id: group.id, page: page });
+      }
+    });
+  };
+
+  return (
+    <PhotoListView
+      title={t("photos.photos")}
+      loading={fetchedPhotosetType !== PhotosetType.PHOTOS}
+      icon={<Star size={50} />}
+      photoset={photosGroupedByDate}
+      updateGroups={getAlbums}
+      idx2hash={photosFlat}
+      selectable
+    />
+  );
+}

--- a/src/layouts/photos/OnlyVideos.tsx
+++ b/src/layouts/photos/OnlyVideos.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Star } from "tabler-icons-react";
+
+import { fetchAlbumDate, fetchAlbumDateList } from "../../actions/albumsActions";
+import { PhotoListView } from "../../components/photolist/PhotoListView";
+import type { PhotosState } from "../../reducers/photosReducer";
+import { PhotosetType } from "../../reducers/photosReducer";
+import { useAppDispatch, useAppSelector } from "../../store/store";
+
+type FetchedGroup = {
+  id: string;
+  page: number;
+};
+
+export function OnlyVideos() {
+  const { fetchedPhotosetType, photosFlat, photosGroupedByDate } = useAppSelector(state => state.photos as PhotosState);
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation();
+
+  const [group, setGroup] = useState({} as FetchedGroup);
+
+  useEffect(() => {
+    if (group.id && group.page) {
+      fetchAlbumDate(dispatch, {
+        album_date_id: group.id,
+        page: group.page,
+        photosetType: PhotosetType.VIDEOS,
+      });
+    }
+  }, [group.id, group.page]);
+
+  useEffect(() => {
+    if (fetchedPhotosetType !== PhotosetType.VIDEOS) {
+      fetchAlbumDateList(dispatch, { photosetType: PhotosetType.VIDEOS });
+    }
+  }, [dispatch]); // Only run on first render
+
+  const getAlbums = (visibleGroups: any) => {
+    visibleGroups.forEach((group: any) => {
+      const visibleImages = group.items;
+      if (visibleImages.filter((i: any) => i.isTemp && i.isTemp !== undefined).length > 0) {
+        const firstTempObject = visibleImages.filter((i: any) => i.isTemp)[0];
+        const page = Math.ceil((parseInt(firstTempObject.id,10) + 1) / 100);
+        setGroup({ id: group.id, page: page });
+      }
+    });
+  };
+
+  return (
+    <PhotoListView
+      title={t("photos.videos")}
+      loading={fetchedPhotosetType !== PhotosetType.VIDEOS}
+      icon={<Star size={50} />}
+      photoset={photosGroupedByDate}
+      updateGroups={getAlbums}
+      idx2hash={photosFlat}
+      selectable
+    />
+  );
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -253,6 +253,7 @@
     "favorites": "Favorites",
     "mypublicphotos": "My Public Photos",
     "photos": "Photos",
+    "videos":"Videos",
     "albums": "Albums",
     "people": "People",
     "places": "Places",
@@ -350,6 +351,7 @@
     "notimestamp": "Photos without Timestamps",
     "hidden": "Hidden Photos",
     "favorite": "Favorite Photos",
+    "videos" :"Videos",
     "deleted": "Trash"
   },
   "login": {

--- a/src/reducers/photosReducer.ts
+++ b/src/reducers/photosReducer.ts
@@ -23,6 +23,7 @@ export enum PhotosetType {
   TIMESTAMP = "timestamp",
   NO_TIMESTAMP = "noTimestamp",
   FAVORITES = "favorites",
+  PHOTOS = "photos",
   HIDDEN = "hidden",
   RECENTLY_ADDED = "recentlyAdded",
   DELETED = "deleted",
@@ -32,6 +33,7 @@ export enum PhotosetType {
   PUBLIC = "public",
   SHARED_TO_ME = "sharedToMe",
   SHARED_BY_ME = "sharedByMe",
+  VIDEOS= "videos",
 }
 
 export interface PhotosState {


### PR DESCRIPTION
issue: Video library filter #[750](https://github.com/LibrePhotos/librephotos/issues/750)
what has been done :
have created 2 filter types for filter only videos and only photos

1)photos for filtering only photos 
2)videos for filtering only videos 
<img width="261" alt="Screenshot 2023-10-22 at 9 03 00 PM" src="https://github.com/LibrePhotos/librephotos-frontend/assets/85862184/4eb83bd9-773b-4a6e-9d50-031627e1f197">
