### PR TITLE
Force refetching faces when adding a new person

### DIFF
--- a/src/components/modals/ModalPersonEdit.tsx
+++ b/src/components/modals/ModalPersonEdit.tsx
@@ -14,6 +14,7 @@ import { fuzzyMatch } from "../../util/util";
 type Props = {
   isOpen: boolean;
   onRequestClose: () => void;
+  resetGroups: () => void;
   selectedFaces: any[];
 };
 
@@ -25,7 +26,7 @@ export function ModalPersonEdit(props: Props) {
 
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
-  const { isOpen, onRequestClose, selectedFaces } = props;
+  const { isOpen, onRequestClose, selectedFaces, resetGroups } = props;
   let filteredPeopleList = people;
 
   if (newPersonName.length > 0) {
@@ -94,6 +95,7 @@ export function ModalPersonEdit(props: Props) {
                 title: i18n.t<string>("toasts.addfacestopersontitle"),
                 color: "teal",
               });
+              resetGroups();
               onRequestClose();
               setNewPersonName("");
             }}

--- a/src/layouts/dataviz/FaceDashboard.tsx
+++ b/src/layouts/dataviz/FaceDashboard.tsx
@@ -385,6 +385,10 @@ export function FaceDashboard() {
           setModalPersonEditOpen(false);
           setSelectedFaces([]);
         }}
+        resetGroups={() => {
+          // Reset groups to force refetch of faces when adding faces to a person
+          setGroups([]);
+        }}
         selectedFaces={selectedFaces}
       />
       {lightboxShow && (


### PR DESCRIPTION
This pull requests fixes https://github.com/LibrePhotos/librephotos/issues/1067

When adding a person, it could happen that a person was added, but never was fetched as it thought that this particular faces is already loaded. By reseting the groups faces will get fetched again for all groups.