### PR TITLE
mark component props readonly

### DIFF
--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -4,9 +4,9 @@ import { Map, Marker, Popup, TileLayer } from "react-leaflet";
 
 import { getAveragedCoordinates } from "../util/util";
 
-type Props = {
+type Props = Readonly<{
   photos: any[];
-};
+}>;
 
 export function LocationMap({ photos }: Props) {
   const mapRef = useRef<Map>(null);

--- a/src/components/album/ModalAlbumEdit.tsx
+++ b/src/components/album/ModalAlbumEdit.tsx
@@ -13,11 +13,11 @@ import { i18nResolvedLanguage } from "../../i18n";
 import { fuzzyMatch } from "../../util/util";
 import { Tile } from "../Tile";
 
-type Props = {
+type Props = Readonly<{
   isOpen: boolean;
   onRequestClose: () => void;
   selectedImages: any[];
-};
+}>;
 
 export function ModalAlbumEdit(props: Props) {
   const [newAlbumTitle, setNewAlbumTitle] = useState("");

--- a/src/components/charts/FaceClusterGraph.tsx
+++ b/src/components/charts/FaceClusterGraph.tsx
@@ -8,9 +8,9 @@ import { api } from "../../api_client/api";
 import { serverAddress } from "../../api_client/apiClient";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   height: number;
-};
+}>;
 
 export function FaceClusterGraph({ height }: Props) {
   const [hintValue, setHintValue] = useState<any>({} as any);

--- a/src/components/charts/WordCloud.tsx
+++ b/src/components/charts/WordCloud.tsx
@@ -6,10 +6,10 @@ import { Chart, Cloud, Transform } from "rumble-charts";
 
 import { useAppSelector } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   type: string;
   height: number;
-};
+}>;
 
 export function WordCloud(props: Props) {
   const { observe: observeChange, width } = useDimensions({

--- a/src/components/facedashboard/ButtonHeaderGroup.tsx
+++ b/src/components/facedashboard/ButtonHeaderGroup.tsx
@@ -26,14 +26,14 @@ import { FacesOrderOption } from "../../store/faces/facesActions.types";
 import type { IFacesOrderOption } from "../../store/faces/facesActions.types";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   selectMode: boolean;
   selectedFaces: any;
   changeSelectMode: () => void;
   addFaces: () => void;
   deleteFaces: () => void;
   notThisPerson: () => void;
-};
+}>;
 
 export function ButtonHeaderGroup({
   selectMode,

--- a/src/components/facedashboard/FaceComponent.tsx
+++ b/src/components/facedashboard/FaceComponent.tsx
@@ -7,7 +7,7 @@ import { serverAddress } from "../../api_client/apiClient";
 import { useAppSelector } from "../../store/store";
 import { FaceTooltip } from "./FaceTooltip";
 
-type Props = {
+type Props = Readonly<{
   cell: any;
   isScrollingFast: boolean;
   selectMode: boolean;
@@ -15,7 +15,7 @@ type Props = {
   isSelected: boolean;
   handleClick: (e: any, cell: any) => void;
   handleShowClick: (e: any, cell: any) => void;
-};
+}>;
 
 export function FaceComponent({
   cell,

--- a/src/components/facedashboard/FaceTooltip.tsx
+++ b/src/components/facedashboard/FaceTooltip.tsx
@@ -6,11 +6,11 @@ import React from "react";
 import { i18nResolvedLanguage } from "../../i18n";
 import { useAppSelector } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   tooltipOpened: boolean;
   cell: any;
   children?: React.ReactNode;
-};
+}>;
 
 export function FaceTooltip({ tooltipOpened, cell, children }: Props) {
   const { activeTab } = useAppSelector(store => store.face);

--- a/src/components/facedashboard/FacesCountersHoverCard.tsx
+++ b/src/components/facedashboard/FacesCountersHoverCard.tsx
@@ -6,10 +6,10 @@ import { FacesTab } from "../../store/faces/facesActions.types";
 import type { IFacesTab } from "../../store/faces/facesActions.types";
 import { useAppSelector } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   tab: IFacesTab;
   children: React.ReactNode;
-};
+}>;
 
 export function FacesCountersHoverCard({ tab, children }: Props) {
   const { inferredFacesList, labeledFacesList } = useAppSelector(store => store.face);

--- a/src/components/facedashboard/TabComponent.tsx
+++ b/src/components/facedashboard/TabComponent.tsx
@@ -1,17 +1,18 @@
 import { Group, Loader, Tabs } from "@mantine/core";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useAppSelector, useAppDispatch } from "../../store/store";
-import { FacesCountersHoverCard } from "./FacesCountersHoverCard";
+
 import { faceActions } from "../../store/faces/faceSlice";
 import { FacesTab } from "../../store/faces/facesActions.types";
-import type {IFacesTab} from "../../store/faces/facesActions.types";
+import type { IFacesTab } from "../../store/faces/facesActions.types";
+import { useAppDispatch, useAppSelector } from "../../store/store";
+import { FacesCountersHoverCard } from "./FacesCountersHoverCard";
 
-type Props = {
+type Props = Readonly<{
   width: number;
   fetchingLabeledFacesList: boolean;
   fetchingInferredFacesList: boolean;
-};
+}>;
 
 export function TabComponent({ width, fetchingLabeledFacesList, fetchingInferredFacesList }: Props) {
   const dispatch = useAppDispatch();

--- a/src/components/job/DeleteJobButton.tsx
+++ b/src/components/job/DeleteJobButton.tsx
@@ -5,17 +5,12 @@ import { useTranslation } from "react-i18next";
 import type { Job } from "../../api_client/admin-jobs";
 import { useDeleteJobMutation } from "../../api_client/admin-jobs";
 
-export function DeleteJobButton({ job }: { job: Job }) {
+export function DeleteJobButton({ job }: Readonly<{ job: Job }>) {
   const { t } = useTranslation();
   const [deleteJob] = useDeleteJobMutation();
 
   return (
-    <Button
-      onClick={() => deleteJob(job.id)}
-      color="red"
-      variant="outline"
-      size="xs"
-    >
+    <Button onClick={() => deleteJob(job.id)} color="red" variant="outline" size="xs">
       {t("adminarea.remove")}
     </Button>
   );

--- a/src/components/job/JobDuration.tsx
+++ b/src/components/job/JobDuration.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from "react-i18next";
 
 import { i18nResolvedLanguage } from "../../i18n";
 
-interface IJobDuration {
+type IJobDuration = Readonly<{
   matches: boolean;
   finished: boolean;
   finishedAt: string | null;
   startedAt: string | null;
-}
+}>;
 
 export function JobDuration({ matches, finished, finishedAt, startedAt }: IJobDuration): JSX.Element | null {
   const { t } = useTranslation();

--- a/src/components/job/JobProgress.tsx
+++ b/src/components/job/JobProgress.tsx
@@ -2,12 +2,12 @@ import { Center, Progress } from "@mantine/core";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-interface IJobProgress {
+type IJobProgress = Readonly<{
   target?: number;
   current?: number;
   finished: boolean;
   error: unknown;
-}
+}>;
 
 export function JobProgress({ target, current, finished, error }: IJobProgress) {
   const { t } = useTranslation();

--- a/src/components/lightbox/Description.tsx
+++ b/src/components/lightbox/Description.tsx
@@ -18,10 +18,11 @@ import { fuzzyMatch } from "../../util/util";
 import "./Hashtag.css";
 import suggestion from "./Suggestion";
 
-type Props = {
+type Props = Readonly<{
   isPublic: boolean;
   photoDetail: PhotoType;
-};
+}>;
+
 export function Description(props: Props) {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();

--- a/src/components/lightbox/FileInfoComponent.tsx
+++ b/src/components/lightbox/FileInfoComponent.tsx
@@ -1,7 +1,7 @@
 import { Group, Text } from "@mantine/core";
 import React from "react";
 
-export function FileInfoComponent(props: { description?: string; info: string | undefined }) {
+export function FileInfoComponent(props: Readonly<{ description?: string; info: string | undefined }>) {
   const { description, info } = props;
 
   if (!info || info.includes("undefined") || info.includes("null") || info.includes("0 mm")) return null;

--- a/src/components/lightbox/LightBox.tsx
+++ b/src/components/lightbox/LightBox.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from "../../store/store";
 import { Sidebar } from "./Sidebar";
 import { Toolbar } from "./Toolbar";
 
-type Props = {
+type Props = Readonly<{
   lightboxImageId: any;
   lightboxImageIndex: any;
   idx2hash: any;
@@ -18,7 +18,7 @@ type Props = {
   onMovePrevRequest: () => void;
   onMoveNextRequest: () => void;
   onImageLoad: () => void;
-};
+}>;
 
 export function LightBox(props: Props) {
   const [lightboxSidebarShow, setLightBoxSidebarShow] = useState(false);

--- a/src/components/lightbox/Sidebar.tsx
+++ b/src/components/lightbox/Sidebar.tsx
@@ -32,6 +32,7 @@ type Props = {
   photoDetail: PhotoType;
   closeSidepanel: () => void;
 };
+
 export function Sidebar(props: Props) {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();

--- a/src/components/lightbox/TimestampItem.tsx
+++ b/src/components/lightbox/TimestampItem.tsx
@@ -17,9 +17,9 @@ import { editPhoto } from "../../actions/photosActions";
 import { i18nResolvedLanguage } from "../../i18n";
 import { useAppDispatch } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   photoDetail: any;
-};
+}>;
 
 export function TimestampItem({ photoDetail }: Props) {
   const [timestamp, setTimestamp] = useState(

--- a/src/components/lightbox/Toolbar.tsx
+++ b/src/components/lightbox/Toolbar.tsx
@@ -16,12 +16,12 @@ import { playerActions } from "../../store/player/playerSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 import { copyToClipboard } from "../../util/util";
 
-type Props = {
+type Props = Readonly<{
   photosDetail: any;
   isPublic: boolean;
   lightboxSidebarShow: boolean;
   closeSidepanel: () => void;
-};
+}>;
 
 export function Toolbar(props: Props) {
   const dispatch = useAppDispatch();

--- a/src/components/lightbox/VersionComponent.tsx
+++ b/src/components/lightbox/VersionComponent.tsx
@@ -9,7 +9,7 @@ import { serverAddress } from "../../api_client/apiClient";
 import { useAppDispatch } from "../../store/store";
 import { FileInfoComponent } from "./FileInfoComponent";
 
-export function VersionComponent(props: { photoDetail: PhotoType }) {
+export function VersionComponent(props: Readonly<{ photoDetail: PhotoType }>) {
   const { photoDetail } = props;
 
   const [showMore, setShowMore] = useState(false);

--- a/src/components/menubars/TopMenuPublic.tsx
+++ b/src/components/menubars/TopMenuPublic.tsx
@@ -9,9 +9,9 @@ import { toggleSidebar } from "../../actions/uiActions";
 import { api } from "../../api_client/api";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 
-type Props = {
+type Props = Readonly<{
   onToggleSidebar: () => void;
-};
+}>;
 
 export function TopMenuCommon({ onToggleSidebar }: Props) {
   return (

--- a/src/components/menubars/WorkerIndicator.tsx
+++ b/src/components/menubars/WorkerIndicator.tsx
@@ -6,9 +6,9 @@ import { useTranslation } from "react-i18next";
 import { useWorkerStatus } from "../../hooks/useWorkerStatus";
 import type { IJobDetailSchema } from "../../store/worker/worker.zod";
 
-interface IWorkerIndicator {
+type IWorkerIndicator = Readonly<{
   workerRunningJob: IJobDetailSchema;
-}
+}>;
 
 function WorkerRunningJob({ workerRunningJob }: IWorkerIndicator) {
   const { t } = useTranslation();

--- a/src/components/modals/ModalConfigDatetime.tsx
+++ b/src/components/modals/ModalConfigDatetime.tsx
@@ -7,12 +7,12 @@ import { fuzzyMatch } from "../../util/util";
 import { getRuleExtraInfo, useDateTimeSettingsStyles } from "../settings/date-time-settings";
 import type { DateTimeRule } from "../settings/date-time.zod";
 
-type Props = {
+type Props = Readonly<{
   opened: boolean;
   onClose: () => void;
   onAddRules: (item: any) => void;
   availableRules: DateTimeRule[];
-};
+}>;
 
 function searchRules(query: string) {
   return function cb(rule: DateTimeRule) {

--- a/src/components/modals/ModalNextcloudScanDirectoryEdit.tsx
+++ b/src/components/modals/ModalNextcloudScanDirectoryEdit.tsx
@@ -7,12 +7,12 @@ import FileExplorerTheme from "react-sortable-tree-theme-file-explorer";
 import type { DirTreeResponse } from "../../api_client/dir-tree";
 import { useFetchNextcloudDirsQuery } from "../../api_client/nextcloud";
 
-type Props = {
+type Props = Readonly<{
   path: string;
   isOpen: boolean;
   onChange: (dir: string) => void;
   onClose: () => void;
-};
+}>;
 
 export function ModalNextcloudScanDirectoryEdit(props: Props) {
   const { t } = useTranslation();

--- a/src/components/modals/ModalPersonEdit.tsx
+++ b/src/components/modals/ModalPersonEdit.tsx
@@ -22,12 +22,12 @@ import { notification } from "../../service/notifications";
 import { useAppDispatch } from "../../store/store";
 import { fuzzyMatch } from "../../util/util";
 
-type Props = {
+type Props = Readonly<{
   isOpen: boolean;
   onRequestClose: () => void;
   resetGroups?: () => void;
   selectedFaces: any[];
-};
+}>;
 
 export function ModalPersonEdit(props: Props) {
   const [newPersonName, setNewPersonName] = useState("");

--- a/src/components/modals/ModalUserDelete.tsx
+++ b/src/components/modals/ModalUserDelete.tsx
@@ -5,11 +5,11 @@ import { Trans, useTranslation } from "react-i18next";
 
 import { useDeleteUserMutation } from "../../api_client/api";
 
-type Props = {
+type Props = Readonly<{
   isOpen: boolean;
   userToDelete: any;
   onRequestClose: () => void;
-};
+}>;
 
 export function ModalUserDelete(props: Props) {
   const { isOpen, onRequestClose, userToDelete } = props;

--- a/src/components/modals/ModalUserEdit.tsx
+++ b/src/components/modals/ModalUserEdit.tsx
@@ -16,7 +16,7 @@ import { IUser } from "../../store/user/user.zod";
 import { EMAIL_REGEX, mergeDirTree } from "../../util/util";
 import { PasswordEntry } from "../settings/PasswordEntry";
 
-type Props = {
+type Props = Readonly<{
   isOpen: boolean;
   updateAndScan?: boolean;
   userToEdit: any;
@@ -25,7 +25,7 @@ type Props = {
   userList: any;
   createNew: boolean;
   firstTimeSetup?: boolean;
-};
+}>;
 
 const findPath = (tree: DirTree[], path: string): boolean => {
   let result = false;

--- a/src/components/photolist/DefaultHeader.tsx
+++ b/src/components/photolist/DefaultHeader.tsx
@@ -20,7 +20,7 @@ import { i18nResolvedLanguage } from "../../i18n";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 import { ModalUserEdit } from "../modals/ModalUserEdit";
 
-type Props = {
+type Props = Readonly<{
   loading: boolean;
   numPhotosetItems: number;
   numPhotos: number;
@@ -29,7 +29,7 @@ type Props = {
   additionalSubHeader: string;
   dayHeaderPrefix: string;
   date: string;
-};
+}>;
 
 export function DefaultHeader(props: Props) {
   const [modalOpen, setModalOpen] = useState(false);

--- a/src/components/photolist/PhotoListView.tsx
+++ b/src/components/photolist/PhotoListView.tsx
@@ -28,7 +28,7 @@ import { VideoOverlay } from "./VideoOverlay";
 
 const TIMELINE_SCROLL_WIDTH = 0;
 
-type Props = {
+type Props = Readonly<{
   title: string;
   loading: boolean;
   icon: any;
@@ -43,7 +43,7 @@ type Props = {
   dayHeaderPrefix?: any;
   header?: any;
   additionalSubHeader?: any;
-};
+}>;
 
 type SelectionState = {
   selectedItems: any[];

--- a/src/components/photolist/VideoOverlay.tsx
+++ b/src/components/photolist/VideoOverlay.tsx
@@ -5,12 +5,12 @@ import React from "react";
 
 import { MediaType } from "../../actions/photosActions.types";
 
-type Props = {
+type Props = Readonly<{
   item: {
     type: MediaType;
     video_length: string;
   };
-};
+}>;
 
 const styles = createStyles(() => ({
   container: {

--- a/src/components/scrollscrubber/ScrollScrubber.tsx
+++ b/src/components/scrollscrubber/ScrollScrubber.tsx
@@ -11,13 +11,13 @@ import "./ScrollScrubber.css";
 import { ScrollerType } from "./ScrollScrubberTypes.zod";
 import type { IScrollerData, IScrollerPosition, IScrollerType } from "./ScrollScrubberTypes.zod";
 
-type Props = {
+type Props = Readonly<{
   type: IScrollerType; // Type of scroller marks to display
   scrollPositions: IScrollerData[]; // Array of positions to show on the scroller (label and Y position on target scrollable area)
   targetHeight: number; // Height of the target scrollable area
   scrollToY: (number) => void; // Callback function that scrolls to a given Y position on target element
   children: ReactNode | null; // Target element must be one of the children nodes
-};
+}>;
 
 export function ScrollScrubber({ type, scrollPositions, targetHeight, scrollToY, children }: Props) {
   // ref and size of scrollscrubber

--- a/src/components/settings/ConfigDateTime.tsx
+++ b/src/components/settings/ConfigDateTime.tsx
@@ -10,10 +10,10 @@ import { ModalConfigDatetime } from "../modals/ModalConfigDatetime";
 import { getRuleExtraInfo, useDateTimeSettingsStyles } from "./date-time-settings";
 import type { DateTimeRule } from "./date-time.zod";
 
-type ConfigDateTimeProps = {
+type ConfigDateTimeProps = Readonly<{
   value: string;
   onChange: (rules: string) => void;
-};
+}>;
 
 function cloneRules(rules: DateTimeRule[]): DateTimeRule[] {
   // poor man's deep-copy

--- a/src/components/settings/PasswordEntry.tsx
+++ b/src/components/settings/PasswordEntry.tsx
@@ -3,11 +3,11 @@ import { IconLock as Lock, IconLockOpen as LockOpen } from "@tabler/icons-react"
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-type Props = {
+type Props = Readonly<{
   createNew?: boolean;
   onValidate: (string, boolean) => void;
   closing?: boolean;
-};
+}>;
 
 export function PasswordEntry(props: Props): JSX.Element {
   const { closing, createNew, onValidate } = props;

--- a/src/components/sharing/ModalAlbumShare.tsx
+++ b/src/components/sharing/ModalAlbumShare.tsx
@@ -8,11 +8,11 @@ import classes from "./ModalAlbumShare.module.css";
 import { UserEntry } from "./UserEntry";
 import filterUsers from "./utils";
 
-type Props = {
+type Props = Readonly<{
   isOpen: boolean;
   onRequestClose: () => void;
   albumID: string;
-};
+}>;
 
 export function ModalAlbumShare(props: Props) {
   const [userNameFilter, setUserNameFilter] = useState("");

--- a/src/components/sharing/ModalPhotosShare.tsx
+++ b/src/components/sharing/ModalPhotosShare.tsx
@@ -12,11 +12,11 @@ import { useAppDispatch, useAppSelector } from "../../store/store";
 import classes from "./ModalAlbumShare.module.css";
 import filterUsers from "./utils";
 
-type Props = {
+type Props = Readonly<{
   selectedImageHashes: any;
   isOpen: boolean;
   onRequestClose: () => void;
-};
+}>;
 
 export function ModalPhotosShare(props: Props) {
   const { t } = useTranslation();

--- a/src/components/sharing/UserEntry.tsx
+++ b/src/components/sharing/UserEntry.tsx
@@ -9,10 +9,10 @@ import { useFetchUserAlbumQuery } from "../../api_client/albums/user";
 import { i18nResolvedLanguage } from "../../i18n";
 import type { IUser } from "../../store/user/user.zod";
 
-type UserEntryProps = {
+type UserEntryProps = Readonly<{
   item: IUser;
   albumID: string;
-};
+}>;
 
 function getDisplayName(item: IUser) {
   return item.first_name.length > 0 && item.last_name.length > 0

--- a/src/layouts/albums/AlbumPlace.tsx
+++ b/src/layouts/albums/AlbumPlace.tsx
@@ -14,9 +14,9 @@ import { serverAddress } from "../../api_client/apiClient";
 import { useAlbumListGridConfig } from "../../hooks/useAlbumListGridConfig";
 import { HeaderComponent } from "./HeaderComponent";
 
-type Props = {
+type Props = Readonly<{
   height?: number;
-};
+}>;
 
 export function AlbumPlace({ height }: Props) {
   const { width } = useViewportSize();

--- a/src/layouts/albums/AlbumUser.tsx
+++ b/src/layouts/albums/AlbumUser.tsx
@@ -25,7 +25,7 @@ import { ModalAlbumShare } from "../../components/sharing/ModalAlbumShare";
 import { useAlbumListGridConfig } from "../../hooks/useAlbumListGridConfig";
 import { HeaderComponent } from "./HeaderComponent";
 
-function SharedWith({ album }: { album: UserAlbumInfo }) {
+function SharedWith({ album }: Readonly<{ album: UserAlbumInfo }>) {
   const [opened, { toggle, close }] = useDisclosure(false);
   // To-Do: Figure out, why album is an array / json <- is it still the case?
   return (


### PR DESCRIPTION
React props should be read-only because it helps to enforce the principle of immutability in React functional components. By making props read-only, you ensure that the data passed from a parent component to a child component cannot be modified directly by the child component. This helps maintain a clear data flow and prevents unexpected side effects.