### PR TITLE
Fixed bug that caused album Map to show wrong or no albums

### DIFF
--- a/src/layouts/albums/AlbumPlace.tsx
+++ b/src/layouts/albums/AlbumPlace.tsx
@@ -33,8 +33,8 @@ export function AlbumPlace({ height }: Props) {
     const ne = map.getBounds().getNorthEast();
     const sw = map.getBounds().getSouthWest();
     const markers = locations.filter(loc => {
-      const markerLat = loc[0];
-      const markerLng = loc[1];
+      const markerLng = loc[0];
+      const markerLat = loc[1];
       return markerLat < ne.lat && markerLat > sw.lat && markerLng < ne.lng && markerLng > sw.lng;
     });
 


### PR DESCRIPTION
I verified that lat and lon were mixed up, then switched it around.
Its working as expected now.