### PR TITLE
Adding support for blurhash

### DIFF
--- a/src/actions/photosActions.types.ts
+++ b/src/actions/photosActions.types.ts
@@ -17,6 +17,7 @@ export enum MediaType {
 export const PigPhotoSchema = z.object({
   id: z.string(),
   dominantColor: z.string().optional(),
+  blurhash: z.string().optional(),
   url: z.string().optional(),
   location: z.string().optional(),
   date: z.string().optional().nullable(),

--- a/src/components/react-pig/components/Tile/Tile.jsx
+++ b/src/components/react-pig/components/Tile/Tile.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { animated, useSpring } from "react-spring";
+import { Blurhash } from "react-blurhash";
 
 import getImageHeight from "../../utils/getImageHeight";
 import getTileMeasurements from "../../utils/getTileMeasurements";
@@ -99,6 +100,13 @@ const Tile = React.memo(
           transform: transform.to(t => t),
         }}
       >
+        {(item.blurhash) && (
+         <Blurhash
+            hash={item.blurhash}
+            width={item.style.width}
+            height={item.style.height}
+          />
+        )}
         {useLqip && !isTemp && (
           // LQIP
           <img
@@ -190,6 +198,7 @@ Tile.defaultProps = {
 const ItemType = PropTypes.shape({
   id: PropTypes.string,
   dominantColor: PropTypes.string,
+  blurhash: PropTypes.string,
   isTemp: PropTypes.bool,
   url: PropTypes.string,
   type: PropTypes.string,


### PR DESCRIPTION
This PR is adding support for [blurhash](https://blurha.sh/), a way to make the loading UI even prettier.

<img src="https://blurha.sh/795ed289706e62297532.png" width="200px"/>

Please note that this PR is a draft because, honestly, I'm not a js expert and need help from the community to get this production ready and working (not to mention I had problems getting this to run locally so I couldn't even verify this works as intended 🤣, so please go easy on me)

This PR is paired with https://github.com/LibrePhotos/librephotos/pull/1490 on the backend