### PR TITLE
Fix timestamp state update

### DIFF
--- a/src/components/lightbox/TimestampItem.tsx
+++ b/src/components/lightbox/TimestampItem.tsx
@@ -43,9 +43,10 @@ export function TimestampItem({ photoDetail, isPublic }: Props) {
   const onChangeDate = (date: Date | null) => {
     if (date && timestamp) {
       const newDate = new Date(date);
-      newDate.setHours(timestamp.getHours());
-      newDate.setMinutes(timestamp.getMinutes());
-      newDate.setSeconds(timestamp.getSeconds());
+      const ts = new Date(timestamp);
+      newDate.setHours(ts.getHours());
+      newDate.setMinutes(ts.getMinutes());
+      newDate.setSeconds(ts.getSeconds());
       setTimestamp(newDate);
     } else {
       setTimestamp(date);


### PR DESCRIPTION
## Summary
- ensure timestamp is converted to `Date` before reading the time parts when a user changes the date

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68757650256483279491cd4958ad4050