### PR TITLE
Fix timestamp edit with missing exif

### DIFF
--- a/src/components/lightbox/TimestampItem.tsx
+++ b/src/components/lightbox/TimestampItem.tsx
@@ -26,8 +26,8 @@ type Props = Readonly<{
 }>;
 
 export function TimestampItem({ photoDetail, isPublic }: Props) {
-  const [timestamp, setTimestamp] = useState(
-    photoDetail.exif_timestamp === null ? null : new Date(photoDetail.exif_timestamp!)
+  const [timestamp, setTimestamp] = useState<Date | null>(
+    photoDetail.exif_timestamp == null ? null : new Date(photoDetail.exif_timestamp)
   );
 
   // savedTimestamp is used to cancel timestamp modification


### PR DESCRIPTION
## Summary
- avoid creating invalid `Date` objects in TimestampItem

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6875f97223888327856d13f7628d0684