### PR TITLE
fix: add instance request method for uploads

### DIFF
--- a/src/api_client/api.ts
+++ b/src/api_client/api.ts
@@ -112,7 +112,7 @@ class FetchClient {
   }
 
   static async request<T>(
-    endpoint: string, 
+    endpoint: string,
     options: RequestInit = {}
   ): Promise<T> {
     const cookies = new Cookies();
@@ -180,7 +180,11 @@ class FetchClient {
       throw error;
     }
   }
-  
+
+  request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    return (this.constructor as typeof FetchClient).request<T>(endpoint, options);
+  }
+
   get<T>(endpoint: string): Promise<T> {
     return (this.constructor as typeof FetchClient).request<T>(endpoint, { method: 'GET' });
   }


### PR DESCRIPTION
## Summary
- add instance request wrapper to FetchClient to support fetchClient.request

## Testing
- `yarn lint:warn` *(fails: @typescript-eslint/no-use-before-define etc.)*
- `yarn eslint src/api_client/api.ts`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68bdce1f67208327ad986416da256780