### PR TITLE
fix: prevent double file dialog on upload

### DIFF
--- a/src/components/ChunkedUploadButton.tsx
+++ b/src/components/ChunkedUploadButton.tsx
@@ -159,7 +159,7 @@ export function ChunkedUploadButton() {
    const hasScanDirectory = userSelfDetails?.scan_directory && userSelfDetails.scan_directory.trim() !== "";
 
 
-  const { getRootProps, getInputProps, open } = useDropzone({
+  const { getRootProps, getInputProps } = useDropzone({
     accept: {
       "image/*": [],
       "video/*": [],
@@ -181,7 +181,6 @@ export function ChunkedUploadButton() {
               color="gray"
               variant="light"
               loading={currentSize / totalSize < 1}
-              onClick={hasScanDirectory ? open : undefined}
               disabled={!hasScanDirectory}
               style={!hasScanDirectory ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
             >


### PR DESCRIPTION
## Summary
- avoid triggering file selector twice when uploading files

## Testing
- `yarn lint:warn` (fails: 172 errors, 14 warnings)
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd32169388327b719e123b58794b1