### PR TITLE
Fix double-open file dialog for uploads

### DIFF
--- a/src/components/ChunkedUploadButton.tsx
+++ b/src/components/ChunkedUploadButton.tsx
@@ -164,8 +164,12 @@ export function ChunkedUploadButton() {
       "image/*": [],
       "video/*": [],
     },
-    noClick: !hasScanDirectory,
-    noKeyboard: !hasScanDirectory,
+    // prevent react-dropzone from automatically opening the file dialog
+    // when the dropzone is clicked. We manually trigger it via the button
+    // click handler, which otherwise would result in the dialog opening
+    // twice due to event bubbling.
+    noClick: true,
+    noKeyboard: true,
     onDrop: hasScanDirectory ? onDrop : () => {},
     disabled: !hasScanDirectory,
   });


### PR DESCRIPTION
## Summary
- prevent `react-dropzone` from auto opening dialog
- rely on manual button click to open dialog once

## Testing
- `npm test`
- `yarn lint:warn` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd32169388327b719e123b58794b1